### PR TITLE
Add Text Case Converter

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -14,6 +14,7 @@
         <a href="/key-generation">{ $t('keygen') }</a>
 		<a href="/qrcode">{ $t('qr-code-gen') }</a>
 		<a href="/currency">{ $t('currency') }</a>
+		<a href="/text-case-converter">Text Case Converter</a>
 	</div>
 </nav>
 <slot />

--- a/src/routes/text-case-converter/+page.svelte
+++ b/src/routes/text-case-converter/+page.svelte
@@ -1,0 +1,143 @@
+<script lang="ts">
+	let inputText = '';
+	let outputText = '';
+	let selectedCase = 'uppercase';
+
+	const cases = [
+		{ value: 'uppercase', label: 'Uppercase' },
+		{ value: 'lowercase', label: 'Lowercase' },
+		{ value: 'titlecase', label: 'Title Case' },
+		{ value: 'sentencecase', label: 'Sentence Case' },
+		{ value: 'alternatingcase', label: 'Alternating Case' },
+	];
+
+	function convertText() {
+		switch (selectedCase) {
+			case 'uppercase':
+				outputText = inputText.toUpperCase();
+				break;
+			case 'lowercase':
+				outputText = inputText.toLowerCase();
+				break;
+			case 'titlecase':
+				outputText = toTitleCase(inputText);
+				break;
+			case 'sentencecase':
+				outputText = toSentenceCase(inputText);
+				break;
+			case 'alternatingcase':
+				outputText = toAlternatingCase(inputText);
+				break;
+			default:
+				outputText = inputText;
+		}
+	}
+
+	function toTitleCase(str: string): string {
+		return str.replace(/\w\S*/g, (txt) => {
+			return txt.charAt(0).toUpperCase() + txt.substring(1).toLowerCase();
+		});
+	}
+
+	function toSentenceCase(str: string): string {
+		return str.replace(/(\.|\?)\s*(\w)/g, (match, p1, p2) => {
+			return p1 + ' ' + p2.toUpperCase();
+		}).replace(/^\w/, (match) => {
+			return match.toUpperCase();
+		});
+	}
+
+	function toAlternatingCase(str: string): string {
+		let result = '';
+		for (let i = 0; i < str.length; i++) {
+			if (i % 2 === 0) {
+				result += str[i].toUpperCase();
+			} else {
+				result += str[i].toLowerCase();
+			}
+		}
+		return result;
+	}
+</script>
+
+<head>
+	<title>TxtWizard | Text Case Converter</title>
+	<meta name="description" content="Convert text to uppercase, lowercase, title case, sentence case, and alternating case." />
+</head>
+
+<h2>Text Case Converter</h2>
+
+<div class="container">
+	<div class="form-group">
+		<label for="inputText">Enter Text:</label>
+		<textarea
+			id="inputText"
+			bind:value={inputText}
+			rows="4"
+			placeholder="Enter your text here..."
+		></textarea>
+	</div>
+
+	<div class="form-group">
+		<label for="caseSelect">Select Case:</label>
+		<select id="caseSelect" bind:value={selectedCase}>
+			{#each cases as c}
+				<option value={c.value}>{c.label}</option>
+			{/each}
+		</select>
+	</div>
+
+	<button on:click={convertText}>Convert</button>
+
+	<div class="form-group">
+		<label for="outputText">Output Text:</label>
+		<textarea
+			id="outputText"
+			bind:value={outputText}
+			rows="4"
+			readonly
+			placeholder="Your converted text will appear here..."
+		></textarea>
+	</div>
+</div>
+
+<style>
+	.container {
+		display: flex;
+		flex-direction: column;
+		gap: 15px;
+	}
+
+	.form-group {
+		display: flex;
+		flex-direction: column;
+		margin-bottom: 10px;
+	}
+
+	label {
+		font-weight: bold;
+		margin-bottom: 5px;
+	}
+
+	textarea,
+	select {
+		padding: 8px;
+		border: 1px solid #ccc;
+		border-radius: 4px;
+		font-size: 16px;
+	}
+
+	button {
+		padding: 10px 15px;
+		background-color: #4CAF50;
+		color: white;
+		border: none;
+		border-radius: 4px;
+		cursor: pointer;
+		font-size: 16px;
+	}
+
+	button:hover {
+		background-color: #3e8e41;
+	}
+</style>

--- a/test/routes/+layout.svelte
+++ b/test/routes/+layout.svelte
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/svelte';
+import '@testing-library/jest-dom';
+import Layout from '../src/routes/+layout.svelte';
+import { init } from 'svelte-i18n';
+
+// Mock the svelte-i18n module
+jest.mock('svelte-i18n', () => ({
+  init: jest.fn(),
+  t: jest.fn((key) => key), // Mock t function to return the key
+}));
+
+
+describe('Layout Component', () => {
+  beforeEach(() => {
+    // Reset the mocks before each test
+    jest.clearAllMocks();
+    // Set up svelte-i18n mock
+    init.mockImplementation(() => {
+      return {
+        t: jest.fn(key => key),
+        loadTranslations: jest.fn(),
+        locale: { subscribe: jest.fn() },
+        format: jest.fn(),
+        addTranslations: jest.fn(),
+        locales: [],
+        loading: false
+      };
+    });
+  });
+
+  it('renders navigation links correctly', () => {
+    render(Layout);
+
+    const homeLink = screen.getByRole('link', { name: 'home' });
+    const encryptionLink = screen.getByRole('link', { name: 'encryption' });
+    const decryptionLink = screen.getByRole('link', { name: 'decryption' });
+    const encodingDecodingLink = screen.getByRole('link', { name: 'encoding' });
+    const hashingLink = screen.getByRole('link', { name: 'hashing' });
+    const compressionLink = screen.getByRole('link', { name: 'compression' });
+    const keygenLink = screen.getByRole('link', { name: 'keygen' });
+    const qrcodeLink = screen.getByRole('link', { name: 'qr-code-gen' });
+    const currencyLink = screen.getByRole('link', { name: 'currency' });
+    const textCaseConverterLink = screen.getByRole('link', { name: 'Text Case Converter' });
+
+    expect(homeLink).toBeInTheDocument();
+    expect(encryptionLink).toBeInTheDocument();
+    expect(decryptionLink).toBeInTheDocument();
+    expect(encodingDecodingLink).toBeInTheDocument();
+    expect(hashingLink).toBeInTheDocument();
+    expect(compressionLink).toBeInTheDocument();
+    expect(keygenLink).toBeInTheDocument();
+    expect(qrcodeLink).toBeInTheDocument();
+    expect(currencyLink).toBeInTheDocument();
+    expect(textCaseConverterLink).toBeInTheDocument();
+  });
+
+  it('renders the menu toggle button', () => {
+    render(Layout);
+    const menuToggle = screen.getByRole('button', { name: 'Toggle navigation' });
+    expect(menuToggle).toBeInTheDocument();
+  });
+});

--- a/test/routes/text-case-converter/+page.svelte
+++ b/test/routes/text-case-converter/+page.svelte
@@ -1,0 +1,54 @@
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import '@testing-library/jest-dom';
+import TextCaseConverter from '../../src/routes/text-case-converter/+page.svelte';
+
+describe('TextCaseConverter Component', () => {
+    it('renders the component with correct elements', async () => {
+        render(TextCaseConverter);
+
+        expect(screen.getByText('Text Case Converter')).toBeInTheDocument();
+        expect(screen.getByLabelText('Enter Text:')).toBeInTheDocument();
+        expect(screen.getByLabelText('Select Case:')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Convert' })).toBeInTheDocument();
+        expect(screen.getByLabelText('Output Text:')).toBeInTheDocument();
+    });
+
+    it('updates output text based on selected case and input', async () => {
+        render(TextCaseConverter);
+
+        const inputTextarea = screen.getByLabelText('Enter Text:');
+        const caseSelect = screen.getByLabelText('Select Case:');
+        const convertButton = screen.getByRole('button', { name: 'Convert' });
+        const outputTextarea = screen.getByLabelText('Output Text:');
+
+        // Test Uppercase
+        await fireEvent.input(inputTextarea, { target: { value: 'hello world' } });
+        await fireEvent.change(caseSelect, { target: { value: 'uppercase' } });
+        await fireEvent.click(convertButton);
+        expect(outputTextarea).toHaveValue('HELLO WORLD');
+
+        // Test Lowercase
+        await fireEvent.input(inputTextarea, { target: { value: 'HeLlO WoRlD' } });
+        await fireEvent.change(caseSelect, { target: { value: 'lowercase' } });
+        await fireEvent.click(convertButton);
+        expect(outputTextarea).toHaveValue('hello world');
+
+        // Test Title Case
+        await fireEvent.input(inputTextarea, { target: { value: 'this is a test' } });
+        await fireEvent.change(caseSelect, { target: { value: 'titlecase' } });
+        await fireEvent.click(convertButton);
+        expect(outputTextarea).toHaveValue('This Is A Test');
+
+        // Test Sentence Case
+        await fireEvent.input(inputTextarea, { target: { value: 'this is a test. another sentence?' } });
+        await fireEvent.change(caseSelect, { target: { value: 'sentencecase' } });
+        await fireEvent.click(convertButton);
+        expect(outputTextarea).toHaveValue('This is a test. Another sentence?');
+
+        // Test Alternating Case
+        await fireEvent.input(inputTextarea, { target: { value: 'alternating case' } });
+        await fireEvent.change(caseSelect, { target: { value: 'alternatingcase' } });
+        await fireEvent.click(convertButton);
+        expect(outputTextarea).toHaveValue('AlTeRnAtInG cAsE');
+    });
+});


### PR DESCRIPTION
This commit introduces a text case converter to the application. The converter allows users to transform text into uppercase, lowercase, title case, sentence case, and alternating case.

A new page has been created with an input area, a case selection dropdown, and an output area.  The user can input text, select a conversion type, and view the converted text.