### PR TITLE
fix: repair jwt signature verification flow

### DIFF
--- a/src/lib/utils/jwt.test.ts
+++ b/src/lib/utils/jwt.test.ts
@@ -103,6 +103,28 @@ describe('verifyJwtSignature', () => {
 			status: 'valid'
 		});
 	});
+
+	it('verifies a valid ES256 token with a PEM public key', async () => {
+		const keyPair = await crypto.subtle.generateKey(
+			{
+				name: 'ECDSA',
+				namedCurve: 'P-256'
+			},
+			true,
+			['sign', 'verify']
+		);
+		const privateKeyPem = await exportPrivateKeyPem(keyPair.privateKey);
+		const publicKeyPem = await exportPublicKeyPem(keyPair.publicKey);
+		const result = await generateJwt({
+			header: { alg: 'ES256', typ: 'JWT' },
+			payload: { sub: 'ecdsa-user' },
+			key: privateKeyPem
+		});
+
+		await expect(verifyJwtSignature({ token: result.token, key: publicKeyPem })).resolves.toMatchObject({
+			status: 'valid'
+		});
+	});
 });
 
 describe('generateJwt', () => {

--- a/src/lib/utils/jwt.test.ts
+++ b/src/lib/utils/jwt.test.ts
@@ -16,6 +16,54 @@ function createSigningInput(header: Record<string, unknown>, payload: Record<str
 	return `${toBase64Url(encoder.encode(JSON.stringify(header)))}.${toBase64Url(encoder.encode(JSON.stringify(payload)))}`;
 }
 
+function joseToDer(signature: Uint8Array, partLength: number): Uint8Array {
+	const r = trimLeadingZeros(signature.slice(0, partLength));
+	const s = trimLeadingZeros(signature.slice(partLength));
+	const derR = needsDerPadding(r) ? Uint8Array.from([0, ...r]) : r;
+	const derS = needsDerPadding(s) ? Uint8Array.from([0, ...s]) : s;
+	const payloadLength = 2 + derR.length + 2 + derS.length;
+
+	return Uint8Array.from([
+		0x30,
+		...encodeDerLength(payloadLength),
+		0x02,
+		...encodeDerLength(derR.length),
+		...derR,
+		0x02,
+		...encodeDerLength(derS.length),
+		...derS
+	]);
+}
+
+function trimLeadingZeros(value: Uint8Array): Uint8Array {
+	let index = 0;
+	while (index < value.length - 1 && value[index] === 0) {
+		index += 1;
+	}
+
+	return value.slice(index);
+}
+
+function needsDerPadding(value: Uint8Array): boolean {
+	return value.length > 0 && (value[0] & 0x80) === 0x80;
+}
+
+function encodeDerLength(length: number): number[] {
+	if (length < 0x80) {
+		return [length];
+	}
+
+	const bytes: number[] = [];
+	let remaining = length;
+
+	while (remaining > 0) {
+		bytes.unshift(remaining & 0xff);
+		remaining >>= 8;
+	}
+
+	return [0x80 | bytes.length, ...bytes];
+}
+
 async function signHs256(signingInput: string, secret: string): Promise<string> {
 	const key = await crypto.subtle.importKey(
 		'raw',
@@ -122,6 +170,32 @@ describe('verifyJwtSignature', () => {
 		});
 
 		await expect(verifyJwtSignature({ token: result.token, key: publicKeyPem })).resolves.toMatchObject({
+			status: 'valid'
+		});
+	});
+
+	it('verifies an ES256 token whose signature segment is DER encoded', async () => {
+		const keyPair = await crypto.subtle.generateKey(
+			{
+				name: 'ECDSA',
+				namedCurve: 'P-256'
+			},
+			true,
+			['sign', 'verify']
+		);
+		const signingInput = createSigningInput({ alg: 'ES256', typ: 'JWT' }, { sub: 'der-user' });
+		const signature = await crypto.subtle.sign(
+			{ name: 'ECDSA', hash: 'SHA-256' },
+			keyPair.privateKey,
+			encoder.encode(signingInput)
+		);
+		const rawSignature = new Uint8Array(signature);
+		const derSignature =
+			rawSignature.length === 64 ? joseToDer(rawSignature, 32) : rawSignature;
+		const publicKeyPem = await exportPublicKeyPem(keyPair.publicKey);
+		const token = `${signingInput}.${toBase64Url(derSignature)}`;
+
+		await expect(verifyJwtSignature({ token, key: publicKeyPem })).resolves.toMatchObject({
 			status: 'valid'
 		});
 	});

--- a/src/lib/utils/jwt.ts
+++ b/src/lib/utils/jwt.ts
@@ -59,6 +59,12 @@ const ECDSA_CURVE_BY_ALG = {
 	ES512: 'P-521'
 } as const;
 
+const ECDSA_SIGNATURE_PART_LENGTH = {
+	ES256: 32,
+	ES384: 48,
+	ES512: 66
+} as const;
+
 const RSA_PSS_SALT_LENGTH = {
 	PS256: 32,
 	PS384: 48,
@@ -165,10 +171,17 @@ export async function verifyJwtSignature(params: {
 	}
 
 	const data = textEncoder.encode(parsed.signingInput);
-	const signature = toArrayBuffer(parsed.signature);
 	const cryptoKey = await importVerificationKey(algorithm, params.key, params.secretEncoding ?? 'utf-8');
 	const verificationParams = getVerificationParams(algorithm);
-	const isValid = await crypto.subtle.verify(verificationParams, cryptoKey, signature, data);
+	const verificationSignatures = getVerificationSignatures(parsed.signature, algorithm);
+	let isValid = false;
+
+	for (const signature of verificationSignatures) {
+		isValid = await crypto.subtle.verify(verificationParams, cryptoKey, signature, data);
+		if (isValid) {
+			break;
+		}
+	}
 
 	return isValid
 		? { status: 'valid', message: 'Signature is valid for the supplied key.' }
@@ -211,7 +224,7 @@ export async function generateJwt(params: {
 		cryptoKey,
 		textEncoder.encode(signingInput)
 	);
-	const signatureBytes = new Uint8Array(signature);
+	const signatureBytes = normalizeSignatureForOutput(new Uint8Array(signature), algorithm);
 
 	return {
 		token: `${signingInput}.${encodeBase64Url(signatureBytes)}`,
@@ -468,10 +481,195 @@ function decodePemPrivateKey(pem: string): Uint8Array {
 	return Uint8Array.from(Buffer.from(body, 'base64'));
 }
 
+function normalizeSignatureForVerify(signature: Uint8Array, algorithm: string): Uint8Array {
+	if (!algorithm.startsWith('ES')) {
+		return signature;
+	}
+
+	const partLength = ECDSA_SIGNATURE_PART_LENGTH[algorithm as keyof typeof ECDSA_SIGNATURE_PART_LENGTH];
+	if (signature.length !== partLength * 2) {
+		throw new Error(`Invalid ${algorithm} signature length.`);
+	}
+
+	return joseToDer(signature, partLength);
+}
+
+function normalizeSignatureForOutput(signature: Uint8Array, algorithm: string): Uint8Array {
+	if (!algorithm.startsWith('ES')) {
+		return signature;
+	}
+
+	const partLength = ECDSA_SIGNATURE_PART_LENGTH[algorithm as keyof typeof ECDSA_SIGNATURE_PART_LENGTH];
+	if (signature.length === partLength * 2) {
+		return signature;
+	}
+
+	return derToJose(signature, partLength);
+}
+
 function toArrayBuffer(value: Uint8Array): ArrayBuffer {
 	return value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength) as ArrayBuffer;
 }
 
 function encodeBase64UrlJson(value: JwtValue): string {
 	return encodeBase64Url(textEncoder.encode(JSON.stringify(value)));
+}
+
+function getVerificationSignatures(signature: Uint8Array, algorithm: string): ArrayBuffer[] {
+	if (!algorithm.startsWith('ES')) {
+		return [toArrayBuffer(signature)];
+	}
+
+	const normalized = normalizeSignatureForVerify(signature, algorithm);
+	const rawBuffer = toArrayBuffer(signature);
+	const normalizedBuffer = toArrayBuffer(normalized);
+
+	if (buffersEqual(rawBuffer, normalizedBuffer)) {
+		return [rawBuffer];
+	}
+
+	return [rawBuffer, normalizedBuffer];
+}
+
+function joseToDer(signature: Uint8Array, partLength: number): Uint8Array {
+	const r = trimLeadingZeros(signature.slice(0, partLength));
+	const s = trimLeadingZeros(signature.slice(partLength));
+
+	const derR = needsDerPadding(r) ? prependZero(r) : r;
+	const derS = needsDerPadding(s) ? prependZero(s) : s;
+	const payloadLength = 2 + derR.length + 2 + derS.length;
+
+	return Uint8Array.from([
+		0x30,
+		...encodeDerLength(payloadLength),
+		0x02,
+		...encodeDerLength(derR.length),
+		...derR,
+		0x02,
+		...encodeDerLength(derS.length),
+		...derS
+	]);
+}
+
+function derToJose(signature: Uint8Array, partLength: number): Uint8Array {
+	let offset = 0;
+
+	if (signature[offset++] !== 0x30) {
+		throw new Error('Invalid DER ECDSA signature.');
+	}
+
+	const sequenceLength = readDerLength(signature, offset);
+	offset = sequenceLength.nextOffset;
+
+	if (signature[offset++] !== 0x02) {
+		throw new Error('Invalid DER ECDSA signature.');
+	}
+
+	const rLength = readDerLength(signature, offset);
+	offset = rLength.nextOffset;
+	const r = signature.slice(offset, offset + rLength.length);
+	offset += rLength.length;
+
+	if (signature[offset++] !== 0x02) {
+		throw new Error('Invalid DER ECDSA signature.');
+	}
+
+	const sLength = readDerLength(signature, offset);
+	offset = sLength.nextOffset;
+	const s = signature.slice(offset, offset + sLength.length);
+	offset += sLength.length;
+
+	if (offset !== signature.length || sequenceLength.length <= 0) {
+		throw new Error('Invalid DER ECDSA signature length.');
+	}
+
+	return Uint8Array.from([
+		...leftPad(trimLeadingZeros(r), partLength),
+		...leftPad(trimLeadingZeros(s), partLength)
+	]);
+}
+
+function trimLeadingZeros(value: Uint8Array): Uint8Array {
+	let index = 0;
+	while (index < value.length - 1 && value[index] === 0) {
+		index += 1;
+	}
+
+	return value.slice(index);
+}
+
+function needsDerPadding(value: Uint8Array): boolean {
+	return value.length > 0 && (value[0] & 0x80) === 0x80;
+}
+
+function prependZero(value: Uint8Array): Uint8Array {
+	return Uint8Array.from([0, ...value]);
+}
+
+function encodeDerLength(length: number): number[] {
+	if (length < 0x80) {
+		return [length];
+	}
+
+	const bytes: number[] = [];
+	let remaining = length;
+
+	while (remaining > 0) {
+		bytes.unshift(remaining & 0xff);
+		remaining >>= 8;
+	}
+
+	return [0x80 | bytes.length, ...bytes];
+}
+
+function readDerLength(value: Uint8Array, offset: number): { length: number; nextOffset: number } {
+	const first = value[offset];
+	if (first === undefined) {
+		throw new Error('Invalid DER length.');
+	}
+
+	if ((first & 0x80) === 0) {
+		return { length: first, nextOffset: offset + 1 };
+	}
+
+	const byteCount = first & 0x7f;
+	if (byteCount === 0 || byteCount > 4) {
+		throw new Error('Unsupported DER length encoding.');
+	}
+
+	let length = 0;
+	for (let index = 0; index < byteCount; index += 1) {
+		length = (length << 8) | value[offset + 1 + index];
+	}
+
+	return { length, nextOffset: offset + 1 + byteCount };
+}
+
+function leftPad(value: Uint8Array, length: number): Uint8Array {
+	if (value.length > length) {
+		throw new Error('ECDSA signature part is longer than expected.');
+	}
+
+	if (value.length === length) {
+		return value;
+	}
+
+	return Uint8Array.from([...new Uint8Array(length - value.length), ...value]);
+}
+
+function buffersEqual(left: ArrayBuffer, right: ArrayBuffer): boolean {
+	if (left.byteLength !== right.byteLength) {
+		return false;
+	}
+
+	const leftView = new Uint8Array(left);
+	const rightView = new Uint8Array(right);
+
+	for (let index = 0; index < leftView.length; index += 1) {
+		if (leftView[index] !== rightView[index]) {
+			return false;
+		}
+	}
+
+	return true;
 }

--- a/src/lib/utils/jwt.ts
+++ b/src/lib/utils/jwt.ts
@@ -177,9 +177,14 @@ export async function verifyJwtSignature(params: {
 	let isValid = false;
 
 	for (const signature of verificationSignatures) {
-		isValid = await crypto.subtle.verify(verificationParams, cryptoKey, signature, data);
-		if (isValid) {
-			break;
+		try {
+			isValid = await crypto.subtle.verify(verificationParams, cryptoKey, signature, data);
+			if (isValid) {
+				break;
+			}
+		} catch {
+			// Some runtimes reject mismatched ECDSA signature formats instead of returning false.
+			// Keep trying the remaining candidate encodings.
 		}
 	}
 
@@ -481,19 +486,6 @@ function decodePemPrivateKey(pem: string): Uint8Array {
 	return Uint8Array.from(Buffer.from(body, 'base64'));
 }
 
-function normalizeSignatureForVerify(signature: Uint8Array, algorithm: string): Uint8Array {
-	if (!algorithm.startsWith('ES')) {
-		return signature;
-	}
-
-	const partLength = ECDSA_SIGNATURE_PART_LENGTH[algorithm as keyof typeof ECDSA_SIGNATURE_PART_LENGTH];
-	if (signature.length !== partLength * 2) {
-		throw new Error(`Invalid ${algorithm} signature length.`);
-	}
-
-	return joseToDer(signature, partLength);
-}
-
 function normalizeSignatureForOutput(signature: Uint8Array, algorithm: string): Uint8Array {
 	if (!algorithm.startsWith('ES')) {
 		return signature;
@@ -520,15 +512,32 @@ function getVerificationSignatures(signature: Uint8Array, algorithm: string): Ar
 		return [toArrayBuffer(signature)];
 	}
 
-	const normalized = normalizeSignatureForVerify(signature, algorithm);
-	const rawBuffer = toArrayBuffer(signature);
-	const normalizedBuffer = toArrayBuffer(normalized);
+	const candidates: ArrayBuffer[] = [toArrayBuffer(signature)];
+	const partLength = ECDSA_SIGNATURE_PART_LENGTH[algorithm as keyof typeof ECDSA_SIGNATURE_PART_LENGTH];
 
-	if (buffersEqual(rawBuffer, normalizedBuffer)) {
-		return [rawBuffer];
+	try {
+		const joseCandidate =
+			signature.length === partLength * 2 ? signature : derToJose(signature, partLength);
+		const joseBuffer = toArrayBuffer(joseCandidate);
+		if (!candidates.some((candidate) => buffersEqual(candidate, joseBuffer))) {
+			candidates.push(joseBuffer);
+		}
+	} catch {
+		// Ignore conversion failure and fall back to the original signature bytes.
 	}
 
-	return [rawBuffer, normalizedBuffer];
+	try {
+		const derCandidate =
+			signature.length === partLength * 2 ? joseToDer(signature, partLength) : signature;
+		const derBuffer = toArrayBuffer(derCandidate);
+		if (!candidates.some((candidate) => buffersEqual(candidate, derBuffer))) {
+			candidates.push(derBuffer);
+		}
+	} catch {
+		// Ignore conversion failure and fall back to the original signature bytes.
+	}
+
+	return candidates;
 }
 
 function joseToDer(signature: Uint8Array, partLength: number): Uint8Array {

--- a/src/routes/jwt/+page.svelte
+++ b/src/routes/jwt/+page.svelte
@@ -33,6 +33,7 @@
 
 	let generatorAlgorithm: JwtAlgorithm = 'HS256';
 	let generatorSecretEncoding: JwtSecretEncoding = 'utf-8';
+	let previousGeneratorSecretEncoding: JwtSecretEncoding = 'utf-8';
 	let generatorKey = '';
 	let issuer = '';
 	let subject = '';
@@ -56,6 +57,9 @@
 	let parseError = '';
 	let verificationKey = '';
 	let secretEncoding: JwtSecretEncoding = 'utf-8';
+	let previousVerificationSecretEncoding: JwtSecretEncoding = 'utf-8';
+	let verificationInputMode: 'secret' | 'public-key' | 'none' | 'unsupported' | 'unknown' =
+		'unknown';
 	let verificationStatus: 'idle' | 'running' | 'done' = 'idle';
 	let verificationResult = '';
 	let verificationTone: 'neutral' | 'success' | 'danger' | 'warning' = 'neutral';
@@ -87,6 +91,7 @@
 			parsed = null;
 			parseError = '';
 			claimStatuses = [];
+			verificationInputMode = 'unknown';
 			return;
 		}
 
@@ -94,9 +99,11 @@
 			parsed = parseJwt(token);
 			parseError = '';
 			claimStatuses = inspectRegisteredClaims(parsed.payload);
+			verificationInputMode = getVerificationInputMode();
 		} catch (error) {
 			parsed = null;
 			claimStatuses = [];
+			verificationInputMode = 'unknown';
 			parseError = error instanceof Error ? error.message : 'Failed to decode JWT.';
 		}
 	}
@@ -124,8 +131,6 @@
 		return 'unknown';
 	}
 
-	$: verificationInputMode = getVerificationInputMode();
-
 	function getGeneratorInputMode() {
 		if (generatorAlgorithm.startsWith('HS')) {
 			return 'secret';
@@ -150,6 +155,44 @@
 		}
 
 		generatorKey = Buffer.from(randomBytes).toString(generatorSecretEncoding);
+	}
+
+	function handleGeneratorSecretInput(event: Event) {
+		const target = event.target as HTMLInputElement;
+		generatorKey = target.value;
+		generatorSecretEncoding = detectSecretEncoding(target.value, generatorSecretEncoding);
+		previousGeneratorSecretEncoding = generatorSecretEncoding;
+	}
+
+	function handleVerificationSecretInput(event: Event) {
+		const target = event.target as HTMLInputElement;
+		verificationKey = target.value;
+		secretEncoding = detectSecretEncoding(target.value, secretEncoding);
+		previousVerificationSecretEncoding = secretEncoding;
+	}
+
+	function handleGeneratorSecretEncodingChange(event: Event) {
+		const target = event.target as HTMLSelectElement;
+		const nextEncoding = target.value as JwtSecretEncoding;
+		generatorKey = convertSecretEncoding(
+			generatorKey,
+			previousGeneratorSecretEncoding,
+			nextEncoding
+		);
+		generatorSecretEncoding = nextEncoding;
+		previousGeneratorSecretEncoding = nextEncoding;
+	}
+
+	function handleVerificationSecretEncodingChange(event: Event) {
+		const target = event.target as HTMLSelectElement;
+		const nextEncoding = target.value as JwtSecretEncoding;
+		verificationKey = convertSecretEncoding(
+			verificationKey,
+			previousVerificationSecretEncoding,
+			nextEncoding
+		);
+		secretEncoding = nextEncoding;
+		previousVerificationSecretEncoding = nextEncoding;
 	}
 
 	function applyTimeClaimsPreset(durationMinutes: number) {
@@ -197,19 +240,33 @@
 		try {
 			const header = parseJsonObject(generatorHeaderText, 'JWT header');
 			const payload = parseJsonObject(generatorPayloadText, 'JWT payload');
+			const normalizedHeader = {
+				...header,
+				alg: generatorAlgorithm,
+				typ: typeof header.typ === 'string' ? header.typ : 'JWT'
+			};
 			const result = await generateJwt({
-				header: {
-					...header,
-					alg: generatorAlgorithm,
-					typ: typeof header.typ === 'string' ? header.typ : 'JWT'
-				},
+				header: normalizedHeader,
 				payload,
 				key: generatorKey,
 				secretEncoding: generatorSecretEncoding
 			});
 
 			token = result.token;
-			generatorStatus = 'JWT generated and loaded into the decoder below.';
+			if (generatorAlgorithm.startsWith('HS')) {
+				verificationKey = generatorKey;
+				secretEncoding = generatorSecretEncoding;
+				previousVerificationSecretEncoding = generatorSecretEncoding;
+				generatorStatus =
+					'JWT generated, loaded into the decoder, and the HMAC secret was copied to verification.';
+			} else if (generatorAlgorithm === 'none') {
+				verificationKey = '';
+				generatorStatus = 'Unsigned JWT generated and loaded into the decoder below.';
+			} else {
+				verificationKey = '';
+				generatorStatus =
+					'JWT generated and loaded into the decoder below. Verification requires the matching public key.';
+			}
 			generatorTone = 'success';
 			decodeToken();
 		} catch (error) {
@@ -271,6 +328,76 @@
 		delete target[key];
 	}
 
+	function detectSecretEncoding(
+		value: string,
+		currentEncoding: JwtSecretEncoding
+	): JwtSecretEncoding {
+		const trimmedValue = value.trim();
+		if (!trimmedValue) {
+			return currentEncoding;
+		}
+
+		if (isLikelyHex(trimmedValue)) {
+			return 'hex';
+		}
+
+		if (isLikelyBase64(trimmedValue)) {
+			return 'base64';
+		}
+
+		return 'utf-8';
+	}
+
+	function convertSecretEncoding(
+		value: string,
+		fromEncoding: JwtSecretEncoding,
+		toEncoding: JwtSecretEncoding
+	): string {
+		if (!value || fromEncoding === toEncoding) {
+			return value;
+		}
+
+		try {
+			if (fromEncoding === 'utf-8') {
+				return Buffer.from(value, 'utf-8').toString(toEncoding);
+			}
+
+			if (toEncoding === 'utf-8') {
+				return Buffer.from(value, fromEncoding).toString('utf-8');
+			}
+
+			return Buffer.from(value, fromEncoding).toString(toEncoding);
+		} catch {
+			return value;
+		}
+	}
+
+	function isLikelyHex(value: string): boolean {
+		return value.length >= 16 && value.length % 2 === 0 && /^[0-9a-fA-F]+$/.test(value);
+	}
+
+	function isLikelyBase64(value: string): boolean {
+		if (value.length < 8 || /[^A-Za-z0-9+/=]/.test(value) || isLikelyHex(value)) {
+			return false;
+		}
+
+		const normalizedValue = value.replace(/=+$/g, '');
+
+		try {
+			const decoded = Buffer.from(value, 'base64');
+			if (decoded.length === 0) {
+				return false;
+			}
+
+			const reEncoded = decoded.toString('base64').replace(/=+$/g, '');
+			const hasBase64Signal = /[+/=]/.test(value) || /[A-Z]/.test(value) || /\d/.test(value);
+
+			return hasBase64Signal && reEncoded === normalizedValue;
+		} catch {
+			return false;
+		}
+	}
+
 	const pageTitle = 'TxtWizard | Free Online JWT Decoder, Generator, and Verification Viewer';
 	const pageDescription =
 		'Generate JWTs, decode headers and claims, inspect exp/nbf/iat, and verify HS, RS, PS, or ES signatures directly in your browser.';
@@ -308,7 +435,11 @@
 			{#if getGeneratorInputMode() === 'secret'}
 				<div>
 					<label for="generator-secret-encoding">Secret Encoding</label>
-					<select id="generator-secret-encoding" bind:value={generatorSecretEncoding}>
+					<select
+						id="generator-secret-encoding"
+						bind:value={generatorSecretEncoding}
+						on:change={handleGeneratorSecretEncodingChange}
+					>
 						<option value="utf-8">UTF-8 text</option>
 						<option value="base64">Base64</option>
 						<option value="hex">Hex</option>
@@ -324,6 +455,7 @@
 					id="generator-secret"
 					type="text"
 					bind:value={generatorKey}
+					on:input={handleGeneratorSecretInput}
 					placeholder="Enter the HMAC secret"
 				/>
 				<button type="button" class="secondary-button" on:click={generateRandomSecret}
@@ -451,7 +583,11 @@
 
 			{#if verificationInputMode === 'secret'}
 				<label for="secret-encoding">Secret Encoding</label>
-				<select id="secret-encoding" bind:value={secretEncoding}>
+				<select
+					id="secret-encoding"
+					bind:value={secretEncoding}
+					on:change={handleVerificationSecretEncodingChange}
+				>
 					<option value="utf-8">UTF-8 text</option>
 					<option value="base64">Base64</option>
 					<option value="hex">Hex</option>
@@ -462,6 +598,7 @@
 					id="verification-secret"
 					type="text"
 					bind:value={verificationKey}
+					on:input={handleVerificationSecretInput}
 					placeholder="Enter the HMAC secret"
 				/>
 			{:else if verificationInputMode === 'public-key'}


### PR DESCRIPTION
## Summary
- fix JWT verification mode updates in the /jwt viewer UI
- restore robust ECDSA sign/verify handling across browser signature formats
- auto-sync and convert HMAC shared secret encodings for easier manual verification

## Verification
- npm run check
- npm run test:unit -- --run
- manual UI verification in 
pm run dev for HS256 generation and verification