### PR TITLE
Replace DOM-based HTML entity decoding with regex parser

### DIFF
--- a/src/lib/utils/encoding.ts
+++ b/src/lib/utils/encoding.ts
@@ -104,10 +104,31 @@ export function encodeHtmlEntities(str: string): string {
 	});
 }
 
+const namedHtmlEntities: Record<string, string> = {
+	amp: '&',
+	lt: '<',
+	gt: '>',
+	quot: '"',
+	apos: "'",
+	nbsp: '\u00A0'
+};
+
 export function decodeHtmlEntities(str: string): string {
-	const textarea = document.createElement('textarea');
-	textarea.innerHTML = str;
-	return textarea.value;
+	return str.replace(/&(#x[0-9a-fA-F]+|#\d+|[a-zA-Z]+);/g, (match, entity: string) => {
+		if (entity[0] === '#') {
+			const isHex = entity[1] === 'x' || entity[1] === 'X';
+			const code = isHex ? parseInt(entity.slice(2), 16) : parseInt(entity.slice(1), 10);
+			if (!Number.isFinite(code) || code < 0 || code > 0x10ffff) {
+				return match;
+			}
+			try {
+				return String.fromCodePoint(code);
+			} catch {
+				return match;
+			}
+		}
+		return namedHtmlEntities[entity] ?? match;
+	});
 }
 
 export function isHtmlEncoded(str: string): boolean {

--- a/src/lib/utils/encoding.ts
+++ b/src/lib/utils/encoding.ts
@@ -114,7 +114,7 @@ const namedHtmlEntities: Record<string, string> = {
 };
 
 export function decodeHtmlEntities(str: string): string {
-	return str.replace(/&(#x[0-9a-fA-F]+|#\d+|[a-zA-Z]+);/g, (match, entity: string) => {
+	return str.replace(/&(#[xX][0-9a-fA-F]+|#\d+|[a-zA-Z]+);/g, (match, entity: string) => {
 		if (entity[0] === '#') {
 			const isHex = entity[1] === 'x' || entity[1] === 'X';
 			const code = isHex ? parseInt(entity.slice(2), 16) : parseInt(entity.slice(1), 10);


### PR DESCRIPTION
## Summary
Refactored the `decodeHtmlEntities` function to use a regex-based parser instead of relying on DOM manipulation via `textarea.innerHTML`. This improves performance, removes DOM dependency, and provides better control over entity decoding.

## Key Changes
- Replaced DOM-based decoding (creating a textarea element and reading its value) with a regex pattern that matches HTML entities
- Added `namedHtmlEntities` lookup object containing common HTML entities (amp, lt, gt, quot, apos, nbsp)
- Implemented support for numeric character references:
  - Hexadecimal entities (e.g., `&#x1F600;`)
  - Decimal entities (e.g., `&#128512;`)
- Added validation for numeric code points:
  - Ensures code is finite and within valid Unicode range (0 to 0x10ffff)
  - Returns original match if code point is invalid
  - Handles `String.fromCodePoint()` errors gracefully

## Implementation Details
The new regex pattern `/&(#x[0-9a-fA-F]+|#\d+|[a-zA-Z]+);/g` matches three types of entities:
- Named entities: `&amp;`, `&lt;`, etc.
- Hexadecimal numeric entities: `&#xHHHH;`
- Decimal numeric entities: `&#DDDD;`

The decoder validates all numeric entities and falls back to the original match string if decoding fails, ensuring safe and predictable behavior.

https://claude.ai/code/session_01D6i7XcmVyMRsbMjTFkytM7