### PR TITLE
Deploy application to GitHub Pages

### DIFF
--- a/.github/workflows/build_and_push.yaml
+++ b/.github/workflows/build_and_push.yaml
@@ -1,11 +1,7 @@
-name: Build and Deploy
+name: Manual Kubernetes Deploy
 
 on:
-  push:
-    branches: [ main ]
-    paths-ignore:
-      - 'docs/**'
-      - 'README.md'
+  workflow_dispatch:
 
 env:
   APP_NAME: txtwizard

--- a/.github/workflows/deploy_pages.yaml
+++ b/.github/workflows/deploy_pages.yaml
@@ -1,0 +1,97 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - 'README.md'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: false
+
+env:
+  INDEXNOW_HOST: txtwizard.net
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate build info
+        run: |
+          echo "{\"buildNumber\": \"${GITHUB_RUN_NUMBER}\", \"commit\": \"${GITHUB_SHA}\", \"date\": \"$(date -u +"%Y-%m-%dT%H:%M:%SZ")\"}" > src/build-info.json
+
+      - name: Build static site
+        run: npm run build
+
+      - name: Prepare GitHub Pages artifact
+        run: touch build/.nojekyll
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: build
+          include-hidden-files: true
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+  update-index:
+    runs-on: ubuntu-latest
+    needs: deploy
+
+    steps:
+      - name: Send IndexNow request
+        env:
+          INDEXNOW_KEY: ${{ secrets.INDEXNOW_KEY }}
+        run: |
+          if [ -z "${INDEXNOW_KEY}" ]; then
+            echo "INDEXNOW_KEY is not configured; skipping IndexNow."
+            exit 0
+          fi
+
+          curl --fail -X POST "https://api.indexnow.org/indexnow" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            -d '{
+              "host": "${{ env.INDEXNOW_HOST }}",
+              "key": "'"${INDEXNOW_KEY}"'",
+              "keyLocation": "https://${{ env.INDEXNOW_HOST }}/'"${INDEXNOW_KEY}"'.txt",
+              "urlList": [
+                "https://${{ env.INDEXNOW_HOST }}/compression",
+                "https://${{ env.INDEXNOW_HOST }}/decryption",
+                "https://${{ env.INDEXNOW_HOST }}/encoding-decoding",
+                "https://${{ env.INDEXNOW_HOST }}/encryption",
+                "https://${{ env.INDEXNOW_HOST }}/key-generation",
+                "https://${{ env.INDEXNOW_HOST }}/hashing",
+                "https://${{ env.INDEXNOW_HOST }}/"
+              ]
+            }'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build and Deploy](https://github.com/magicsih/txtwizard/actions/workflows/build_and_push.yaml/badge.svg)](https://github.com/magicsih/txtwizard/actions/workflows/build_and_push.yaml)
+[![Deploy GitHub Pages](https://github.com/magicsih/txtwizard/actions/workflows/deploy_pages.yaml/badge.svg)](https://github.com/magicsih/txtwizard/actions/workflows/deploy_pages.yaml)
 
 # TXTWIZARD
 
@@ -25,7 +25,29 @@ To build the project for production:
 
 ## Deployment
 
-Changes pushed to the `main` branch are automatically deployed to [https://www.txtwizard.net](https://www.txtwizard.net) via the CI/CD pipeline configured in the repository.
+Changes pushed to the `main` branch are automatically deployed to [https://www.txtwizard.net](https://www.txtwizard.net) via GitHub Pages.
+
+The legacy Kubernetes deployment workflow is kept as a manual fallback in `.github/workflows/build_and_push.yaml`.
+
+### GitHub Pages setup
+
+Before the first Pages deployment, configure the repository once:
+
+1. Open `Settings` > `Pages` in the GitHub repository.
+2. Set `Build and deployment` > `Source` to `GitHub Actions`.
+3. Set `Custom domain` to `www.txtwizard.net`.
+4. Enable `Enforce HTTPS` after GitHub finishes issuing the certificate.
+
+Configure DNS for the domain:
+
+- `www.txtwizard.net` CNAME to `magicsih.github.io`
+- `txtwizard.net` A records to GitHub Pages:
+  - `185.199.108.153`
+  - `185.199.109.153`
+  - `185.199.110.153`
+  - `185.199.111.153`
+
+After DNS propagates, GitHub Pages should redirect `txtwizard.net` to `www.txtwizard.net`.
 
 ## Features
 


### PR DESCRIPTION
This pull request updates the deployment process to use GitHub Pages for automatic deployments from the `main` branch, replacing the previous Kubernetes-based workflow. It introduces a new GitHub Actions workflow for building and deploying the static site to GitHub Pages, updates documentation to reflect the new process, and retains the legacy Kubernetes workflow as a manual fallback.

**Deployment workflow changes:**

* Added `.github/workflows/deploy_pages.yaml` to automate building and deploying the site to GitHub Pages on push to `main` or manual trigger, including a post-deploy IndexNow ping for search engine indexing.
* Changed `.github/workflows/build_and_push.yaml` to a manual-only workflow for Kubernetes deployment, renaming it to "Manual Kubernetes Deploy" and removing automatic triggers.

**Documentation updates:**

* Updated the CI badge in `README.md` to reference the new GitHub Pages deployment workflow.
* Revised the deployment section in `README.md` to document the GitHub Pages setup process and clarify that the Kubernetes workflow is now manual and legacy.