### PR TITLE
광고 수익 최적화: 수동 광고 유닛 추가 및 JSON-LD 렌더 수정

### DIFF
--- a/src/lib/ads.ts
+++ b/src/lib/ads.ts
@@ -1,0 +1,31 @@
+// Central AdSense configuration for manual (in-content) ad units.
+//
+// The AdSense loader script and the publisher id are already included globally
+// in src/app.html. This file only tracks the manual ad-unit *slot ids* so the
+// <AdUnit> component can render placed units at high-viewability positions
+// instead of relying solely on Auto Ads.
+//
+// How to fill this in:
+//   1. AdSense console > Ads > By ad unit > Display ads.
+//   2. Create a "Display ad" (responsive) unit for each placement below.
+//   3. Copy the numeric `data-ad-slot` value into the matching entry.
+//
+// Leave an entry as '' until you have the real slot id. Empty slots render
+// nothing in production (no broken/empty <ins>), so it is safe to ship before
+// the ids exist.
+
+export const AD_CLIENT = 'ca-pub-9932778305312246';
+
+export const AD_SLOTS = {
+	// Shown directly below a tool's result area (highest viewability: users
+	// look here right after clicking generate/convert). Reused across tools.
+	toolResult: '8839886302',
+	// Inline unit on the home page.
+	homeInline: '7526804635'
+} as const;
+
+export type AdPlacement = keyof typeof AD_SLOTS;
+
+export function getAdSlot(placement: AdPlacement): string {
+	return AD_SLOTS[placement] ?? '';
+}

--- a/src/lib/components/AdUnit.svelte
+++ b/src/lib/components/AdUnit.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { dev } from '$app/environment';
+	import { AD_CLIENT, getAdSlot, type AdPlacement } from '$lib/ads';
+
+	export let placement: AdPlacement;
+	export let label = 'Advertisement';
+
+	const slot = getAdSlot(placement);
+	const configured = slot.length > 0;
+
+	onMount(() => {
+		if (!configured) return;
+		try {
+			const w = window as unknown as { adsbygoogle?: unknown[] };
+			(w.adsbygoogle = w.adsbygoogle || []).push({});
+		} catch {
+			// Ad blocker or loader not ready yet — safe to ignore.
+		}
+	});
+</script>
+
+{#if configured}
+	<aside class="ad-slot" aria-label={label}>
+		<ins
+			class="adsbygoogle"
+			style="display:block"
+			data-ad-client={AD_CLIENT}
+			data-ad-slot={slot}
+			data-ad-format="auto"
+			data-full-width-responsive="true"
+		></ins>
+	</aside>
+{:else if dev}
+	<aside class="ad-slot ad-placeholder" aria-label="Ad placeholder">
+		<span>Ad slot &ldquo;{placement}&rdquo; — set its id in src/lib/ads.ts</span>
+	</aside>
+{/if}
+
+<style>
+	.ad-slot {
+		display: block;
+		margin: 24px auto;
+		max-width: 1200px;
+		min-height: 90px;
+	}
+
+	.ad-placeholder {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		border: 1px dashed var(--bg-3);
+		border-radius: 8px;
+		background: var(--bg-2);
+		color: var(--fg-2);
+		font-size: 0.85rem;
+		padding: 12px;
+		text-align: center;
+	}
+</style>

--- a/src/lib/components/SeoHead.svelte
+++ b/src/lib/components/SeoHead.svelte
@@ -4,13 +4,20 @@
 	export let path = '/';
 	export let type: 'website' | 'article' = 'website';
 	export let structuredData: Record<string, unknown> | Array<Record<string, unknown>> | null = null;
+	// Social share image. Drop a 1200x630 PNG at static/og-image.png to override
+	// the default (favicon) with a proper Open Graph card.
+	export let image: string | null = null;
 
 	const siteName = 'TxtWizard';
 	const siteUrl = 'https://www.txtwizard.net';
 
 	$: normalizedPath = path === '/' ? '/' : path.replace(/\/+$/, '');
 	$: canonicalUrl = `${siteUrl}${normalizedPath}`;
-	$: structuredDataJson = structuredData ? JSON.stringify(structuredData) : '';
+	$: imageUrl = `${siteUrl}${image ?? '/favicon.png'}`;
+	// Escape "<" so a value can never break out of the closing script tag.
+	$: structuredDataJson = structuredData
+		? JSON.stringify(structuredData).replace(/</g, '\\u003c')
+		: '';
 </script>
 
 <svelte:head>
@@ -22,10 +29,13 @@
 	<meta property="og:title" content={title} />
 	<meta property="og:description" content={description} />
 	<meta property="og:url" content={canonicalUrl} />
-	<meta name="twitter:card" content="summary" />
+	<meta property="og:image" content={imageUrl} />
+	<meta name="twitter:card" content="summary_large_image" />
 	<meta name="twitter:title" content={title} />
 	<meta name="twitter:description" content={description} />
+	<meta name="twitter:image" content={imageUrl} />
 	{#if structuredDataJson}
-		<script type="application/ld+json">{structuredDataJson}</script>
+		<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+		{@html `<script type="application/ld+json">${structuredDataJson}<\/script>`}
 	{/if}
 </svelte:head>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import SeoHead from '$lib/components/SeoHead.svelte';
+	import AdUnit from '$lib/components/AdUnit.svelte';
 	import { t } from 'svelte-i18n';
 	import './+page.css';
 
@@ -150,6 +151,8 @@
 			</div>
 		</div>
 	</section>
+
+	<AdUnit placement="homeInline" />
 
 	<section class="tool-groups">
 		<h2>{$t('our-tools')}</h2>

--- a/src/routes/compression/+page.svelte
+++ b/src/routes/compression/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import SeoHead from '$lib/components/SeoHead.svelte';
+	import AdUnit from '$lib/components/AdUnit.svelte';
 	import { t } from 'svelte-i18n';
 	import {
 		COMPRESSION_ALGORITHMS,
@@ -104,6 +105,8 @@
 		<textarea id="hashHex" bind:value={outHexText} rows="4" readonly></textarea>
 	</div>
 </div>
+
+<AdUnit placement="toolResult" />
 
 <div class="description">
 	<h3>About the Compression Tool</h3>

--- a/src/routes/decryption/+page.svelte
+++ b/src/routes/decryption/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import SeoHead from '$lib/components/SeoHead.svelte';
+	import AdUnit from '$lib/components/AdUnit.svelte';
 	import { t } from 'svelte-i18n';
 	import { trackToolsUsageEvent } from '$lib/utils/analytics';
 	import {
@@ -209,6 +210,8 @@
 		>
 	</div>
 </div>
+
+<AdUnit placement="toolResult" />
 
 <div class="description">
 	<h3>What is Decryption?</h3>

--- a/src/routes/encoding-decoding/+page.svelte
+++ b/src/routes/encoding-decoding/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import SeoHead from '$lib/components/SeoHead.svelte';
+	import AdUnit from '$lib/components/AdUnit.svelte';
 	import { t } from 'svelte-i18n';
 	import { onMount } from 'svelte';
 	import { Buffer } from 'buffer';
@@ -56,9 +57,58 @@
 	const pageTitle = 'TxtWizard | Free Online Text Encoding and Decoding Tool';
 	const pageDescription =
 		'Convert plain text, Base64, Hex, URL encoding, and HTML encoding in a single browser-based tool.';
+
+	const structuredData = [
+		{
+			'@context': 'https://schema.org',
+			'@type': 'SoftwareApplication',
+			name: 'TxtWizard Encoding & Decoding Tool',
+			url: 'https://www.txtwizard.net/encoding-decoding',
+			applicationCategory: 'DeveloperApplication',
+			operatingSystem: 'Any',
+			browserRequirements: 'Requires a modern web browser',
+			description: pageDescription,
+			offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' }
+		},
+		{
+			'@context': 'https://schema.org',
+			'@type': 'FAQPage',
+			mainEntity: [
+				{
+					'@type': 'Question',
+					name: 'Which encodings can this tool convert?',
+					acceptedAnswer: {
+						'@type': 'Answer',
+						text: 'It converts between plain text, Base64, Hex, URL encoding, and HTML encoding.'
+					}
+				},
+				{
+					'@type': 'Question',
+					name: 'Does the encoder send my text anywhere?',
+					acceptedAnswer: {
+						'@type': 'Answer',
+						text: 'No. All encoding and decoding happens in your browser, so the input stays on your device.'
+					}
+				},
+				{
+					'@type': 'Question',
+					name: 'Does it detect the input encoding automatically?',
+					acceptedAnswer: {
+						'@type': 'Answer',
+						text: 'Yes. The tool detects the likely input encoding and shows all conversions at once.'
+					}
+				}
+			]
+		}
+	];
 </script>
 
-<SeoHead title={pageTitle} description={pageDescription} path="/encoding-decoding" />
+<SeoHead
+	title={pageTitle}
+	description={pageDescription}
+	path="/encoding-decoding"
+	{structuredData}
+/>
 
 <h1>{$t('encoding')} & {$t('decoding')} {$t('tool')}</h1>
 
@@ -113,6 +163,8 @@
 		<small>{htmlEncodeLength} letters ({htmlEncodeBytes} bytes in size)</small>
 	</div>
 </div>
+
+<AdUnit placement="toolResult" />
 
 <div class="description">
 	<h3>About the Text Encoding and Decoding Tool</h3>

--- a/src/routes/encryption/+page.svelte
+++ b/src/routes/encryption/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import SeoHead from '$lib/components/SeoHead.svelte';
+	import AdUnit from '$lib/components/AdUnit.svelte';
 	import { t } from 'svelte-i18n';
 	import { trackToolsUsageEvent } from '$lib/utils/analytics';
 	import {
@@ -242,6 +243,8 @@
 		>
 	</div>
 </div>
+
+<AdUnit placement="toolResult" />
 
 <div class="description">
 	<h3>What is Encryption?</h3>

--- a/src/routes/hashing/+page.svelte
+++ b/src/routes/hashing/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import SeoHead from '$lib/components/SeoHead.svelte';
+	import AdUnit from '$lib/components/AdUnit.svelte';
 	import { t } from 'svelte-i18n';
 	import { Buffer } from 'buffer';
 	import { trackToolsUsageEvent } from '$lib/utils/analytics';
@@ -52,9 +53,53 @@
 	const pageTitle = 'TxtWizard | Free Online Hash Generator - SHA, Keccak, BLAKE';
 	const pageDescription =
 		'Generate SHA, SHA-3, Keccak, RIPEMD160, and BLAKE hashes from text directly in your browser.';
+
+	const structuredData = [
+		{
+			'@context': 'https://schema.org',
+			'@type': 'SoftwareApplication',
+			name: 'TxtWizard Hash Generator',
+			url: 'https://www.txtwizard.net/hashing',
+			applicationCategory: 'DeveloperApplication',
+			operatingSystem: 'Any',
+			browserRequirements: 'Requires a modern web browser',
+			description: pageDescription,
+			offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' }
+		},
+		{
+			'@context': 'https://schema.org',
+			'@type': 'FAQPage',
+			mainEntity: [
+				{
+					'@type': 'Question',
+					name: 'Is my text uploaded when I generate a hash?',
+					acceptedAnswer: {
+						'@type': 'Answer',
+						text: 'No. Hashing runs entirely in your browser, so the input never leaves your device.'
+					}
+				},
+				{
+					'@type': 'Question',
+					name: 'Which hash algorithms are supported?',
+					acceptedAnswer: {
+						'@type': 'Answer',
+						text: 'SHA family (including SHA-256), SHA-3/Keccak, RIPEMD160, and BLAKE hashes are supported.'
+					}
+				},
+				{
+					'@type': 'Question',
+					name: 'Can I reverse a hash back into the original text?',
+					acceptedAnswer: {
+						'@type': 'Answer',
+						text: 'No. Hashing is a one-way function, so the original text cannot be recovered from the hash.'
+					}
+				}
+			]
+		}
+	];
 </script>
 
-<SeoHead title={pageTitle} description={pageDescription} path="/hashing" />
+<SeoHead title={pageTitle} description={pageDescription} path="/hashing" {structuredData} />
 
 <header>
 	<h1>{$t('hashing')} {$t('tool')}</h1>
@@ -102,6 +147,9 @@
 			<small>{hexBytes} bytes</small>
 		</div>
 	</section>
+
+	<AdUnit placement="toolResult" />
+
 	<section class="description" aria-label="Information about Hashing">
 		<h2>What is Hashing?</h2>
 		<p>

--- a/src/routes/key-generation/+page.svelte
+++ b/src/routes/key-generation/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import SeoHead from '$lib/components/SeoHead.svelte';
+	import AdUnit from '$lib/components/AdUnit.svelte';
 	import { t } from 'svelte-i18n';
 	import {
 		deriveKeysFromNumericInput,
@@ -143,6 +144,8 @@
 		store your private key, as it is critical for accessing your cryptocurrency assets.
 	</p>
 </div>
+
+<AdUnit placement="toolResult" />
 
 <div class="description">
 	<h3>Outputs:</h3>


### PR DESCRIPTION
## 배경

GA4·AdSense 지표 분석 결과, 광고수익이 사실상 0(월 약 $0.4)이고 오가닉 검색이 수익의 64%를 차지하는데 도구 페이지들의 광고 노출이 페이지뷰당 0.5~1.2개에 그쳐 인벤토리가 새고 있었습니다. 특히 `key-generation`·`compression`이 수익의 85%, `encryption`(평균 61초)·`decryption`(73초)은 체류가 가장 긴데 수익이 바닥이었습니다.

이 PR은 (1) 고체류·고수익 페이지에 통제된 수동 광고 유닛을 배치하고, (2) 그동안 렌더되지 않던 구조화 데이터(JSON-LD)를 복구해 SEO를 개선합니다.

## 변경 사항

### 수동 광고 유닛
- `src/lib/ads.ts`: 광고 슬롯 설정 중앙화(`toolResult`, `homeInline`).
- `src/lib/components/AdUnit.svelte`: 반응형 디스플레이 광고 컴포넌트.
- 배치: 홈 + 6개 주요 도구(compression, key-generation, encryption, decryption, hashing, encoding-decoding)의 **결과 영역 바로 아래**(최고 뷰어빌리티 위치).
- 슬롯 미설정 시 프로덕션에서 아무것도 렌더하지 않아 빈 광고 태그가 노출되지 않습니다(정책 리스크 없음).

### 🐞 JSON-LD 렌더 버그 수정
- 기존 `SeoHead`는 `script` 태그 안에서 중괄호 표현식을 그대로 출력해 **구조화 데이터가 실제로는 한 번도 렌더되지 않았습니다**(검색엔진이 무효 JSON을 수신). `@html` 방식으로 수정해 홈 포함 전 페이지에서 유효한 JSON-LD 출력을 복구했습니다. 값 내부의 `<`는 이스케이프해 태그 이탈을 방지합니다.

### SEO 메타 보강
- `SeoHead`에 `og:image` 및 `summary_large_image` 트위터 카드 추가(전 페이지 소셜/검색 스니펫 개선).
- `hashing`, `encoding-decoding`에 `SoftwareApplication`/`FAQPage` JSON-LD 추가.

## AdUnit 렌더 로직

```mermaid
flowchart TD
    A["도구 또는 홈 페이지 렌더"] --> B["AdUnit placement 지정"]
    B --> C{"슬롯 ID 설정됨?"}
    C -->|"예"| D["adsbygoogle ins 렌더 후 push"]
    C -->|"아니오 - 개발"| E["위치 표시용 placeholder만 표시"]
    C -->|"아니오 - 프로덕션"| F["아무것도 렌더하지 않음"]
```

## 검증
- `npm run check`: 0 errors / 0 warnings
- `npm run build`: 성공
- 빌드 산출물 확인: 7개 페이지 JSON-LD가 유효한 JSON으로 출력, 도구 6개 페이지 + 홈에 광고 유닛 정상 렌더, 리터럴 표현식 잔존 0.

## 운영 참고(코드 외)
- AdSense Auto ads는 콘솔에서 **인페이지·앵커 OFF**로 조정 완료(수동 유닛과 중복 방지, 앵커의 상단 레이아웃 밀림 방지). 비네트/사이드레일은 콘텐츠를 밀지 않으므로 유지 가능.
- 후속: `static/og-image.png`(1200x630) 추가 시 현재 favicon 폴백을 대체. GA4→BigQuery export 데이터가 쌓이면 페이지별 RPM·노출/PV 측정 루프로 배치 효과를 검증할 예정.
