### PR TITLE
어필리에이트: Amazon 추천 박스(하드웨어 지갑·보안키) 추가

### DIFF
--- a/src/lib/affiliate.ts
+++ b/src/lib/affiliate.ts
@@ -1,0 +1,23 @@
+// Amazon Associates configuration.
+export const AMAZON_TAG = 'txtwizard-20';
+
+// Required by the Amazon Associates Operating Agreement — this exact phrase
+// must stay visible near affiliate links.
+export const AMAZON_DISCLOSURE =
+	'As an Amazon Associate, TxtWizard earns from qualifying purchases.';
+
+// Build an Amazon link that carries the affiliate tag.
+//
+// Search links work immediately and need no product ASIN. For higher
+// conversion, replace an item's `url` with a specific product link generated
+// from Amazon SiteStripe (it already includes ?tag=txtwizard-20), e.g.
+//   https://www.amazon.com/dp/<ASIN>?tag=txtwizard-20
+export function amazonSearch(keywords: string): string {
+	return `https://www.amazon.com/s?k=${encodeURIComponent(keywords)}&tag=${AMAZON_TAG}`;
+}
+
+export type AffiliateItem = {
+	label: string;
+	url: string;
+	note?: string;
+};

--- a/src/lib/components/AffiliateBox.svelte
+++ b/src/lib/components/AffiliateBox.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+	import { AMAZON_DISCLOSURE, type AffiliateItem } from '$lib/affiliate';
+
+	export let heading: string;
+	export let intro: string;
+	export let items: AffiliateItem[];
+</script>
+
+<aside class="affiliate" aria-label="Recommended products">
+	<h3>{heading}</h3>
+	<p class="intro">{intro}</p>
+	<ul>
+		{#each items as item}
+			<li>
+				<a href={item.url} target="_blank" rel="nofollow sponsored noopener">{item.label}</a>{#if item.note}<span
+						class="note"
+					>
+						— {item.note}</span
+					>{/if}
+			</li>
+		{/each}
+	</ul>
+	<p class="disclosure">{AMAZON_DISCLOSURE}</p>
+</aside>
+
+<style>
+	.affiliate {
+		margin: 24px auto;
+		max-width: 1200px;
+		padding: 16px 20px;
+		border: 1px solid var(--bg-3);
+		border-radius: 8px;
+		background-color: var(--bg-2);
+		color: var(--fg-1);
+	}
+
+	.affiliate h3 {
+		margin: 0 0 8px;
+	}
+
+	.intro {
+		margin: 0 0 12px;
+	}
+
+	.affiliate ul {
+		margin: 0 0 12px;
+		padding-left: 20px;
+	}
+
+	.affiliate li {
+		margin-bottom: 6px;
+	}
+
+	.note {
+		color: var(--fg-2);
+	}
+
+	.disclosure {
+		margin: 0;
+		font-size: 0.8rem;
+		color: var(--fg-2);
+	}
+</style>

--- a/src/routes/key-generation/+page.svelte
+++ b/src/routes/key-generation/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import SeoHead from '$lib/components/SeoHead.svelte';
 	import AdUnit from '$lib/components/AdUnit.svelte';
+	import AffiliateBox from '$lib/components/AffiliateBox.svelte';
+	import { amazonSearch } from '$lib/affiliate';
 	import { t } from 'svelte-i18n';
 	import {
 		deriveKeysFromNumericInput,
@@ -144,6 +146,23 @@
 		store your private key, as it is critical for accessing your cryptocurrency assets.
 	</p>
 </div>
+
+<AffiliateBox
+	heading="Storing real crypto? Use a hardware wallet"
+	intro="This tool generates keys in your browser — perfect for learning and testing, but not safe for real funds. For actual crypto, use a hardware wallet that creates and stores keys offline:"
+	items={[
+		{
+			label: 'Ledger hardware wallets',
+			url: amazonSearch('Ledger hardware wallet'),
+			note: 'offline key storage'
+		},
+		{
+			label: 'Trezor hardware wallets',
+			url: amazonSearch('Trezor hardware wallet'),
+			note: 'open-source firmware'
+		}
+	]}
+/>
 
 <AdUnit placement="toolResult" />
 

--- a/src/routes/password-generator/+page.svelte
+++ b/src/routes/password-generator/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import SeoHead from '$lib/components/SeoHead.svelte';
+	import AffiliateBox from '$lib/components/AffiliateBox.svelte';
+	import { amazonSearch } from '$lib/affiliate';
 	import { t } from 'svelte-i18n';
 	import {
 		calculatePasswordStrength,
@@ -111,6 +113,14 @@
 		{/if}
 	{/if}
 </div>
+
+<AffiliateBox
+	heading="Beyond passwords: add a hardware security key"
+	intro="A strong generated password is a great start. For the accounts that matter most, add a hardware security key for phishing-resistant two-factor authentication:"
+	items={[
+		{ label: 'YubiKey security keys', url: amazonSearch('YubiKey security key'), note: 'hardware 2FA' }
+	]}
+/>
 
 <style>
 	.container {


### PR DESCRIPTION
## 배경

이 사이트의 오디언스(보안·암호화·개발자)는 AdSense엔 저효율이지만 어필리에이트엔 고가치입니다. 특히 key-generation은 하드웨어 지갑, password-generator는 하드웨어 보안키가 자연스럽고 유용한 추천입니다. 방문자당 가치(EPMV)를 광고 대비 크게 끌어올리는 것이 목표입니다.

## 변경 사항

- `src/lib/affiliate.ts`: Amazon Associates 태그(`txtwizard-20`), 링크 빌더(`amazonSearch`), 필수 공개 문구 중앙화.
- `src/lib/components/AffiliateBox.svelte`: 공개 문구 포함 추천 박스. 외부 링크는 `rel="nofollow sponsored"`.
- `key-generation`: **Ledger, Trezor 하드웨어 지갑** 추천 — "브라우저 생성 키는 학습·테스트용이며 실제 자금은 오프라인 하드웨어 지갑을 쓰라"는 정직한 보안 프레이밍과 함께(사용자에게 실제 유용 + 전환도 유리).
- `password-generator`: **YubiKey 보안키** 추천(피싱 저항 2FA).

## 정책·품질

- **필수 공개 문구** "As an Amazon Associate, TxtWizard earns from qualifying purchases." 포함(Amazon Operating Agreement 요구).
- 링크에 `rel="nofollow sponsored"` 표기.
- 가격 표기 없음(Amazon은 실시간 가격만 허용하므로 정적 가격 미표기).
- 현재는 즉시 작동하는 **Amazon 검색 링크(태그 포함)**. 이후 SiteStripe 특정 상품 링크로 교체 시 전환율 향상.

## 검증

- `npm run check`: 0 errors / 0 warnings, `npm run build`: 성공.
- 빌드 산출물 확인: key-generation 2개(Ledger/Trezor), password-generator 1개(YubiKey) 링크가 `tag=txtwizard-20`·공개문구·`rel` 표기와 함께 정상 렌더.

## 참고

- **180일 규칙**: 가입 후 180일 내 적격 판매 3건 필요 → 트래픽 큰 페이지로 관련 상품을 넓혀갈 여지.
- 국제 방문자 전환을 위해 추후 Amazon OneLink(지역 리다이렉트) 및 Ledger/Trezor 직접 프로그램(고수수료) 병행 고려.
