### PR TITLE
Add Amazon affiliate box for hardware wallets and security keys

### DIFF
--- a/src/lib/affiliate.ts
+++ b/src/lib/affiliate.ts
@@ -1,0 +1,23 @@
+// Amazon Associates configuration.
+export const AMAZON_TAG = 'txtwizard-20';
+
+// Required by the Amazon Associates Operating Agreement — this exact phrase
+// must stay visible near affiliate links.
+export const AMAZON_DISCLOSURE =
+	'As an Amazon Associate, TxtWizard earns from qualifying purchases.';
+
+// Build an Amazon link that carries the affiliate tag.
+//
+// Search links work immediately and need no product ASIN. For higher
+// conversion, replace an item's `url` with a specific product link generated
+// from Amazon SiteStripe (it already includes ?tag=txtwizard-20), e.g.
+//   https://www.amazon.com/dp/<ASIN>?tag=txtwizard-20
+export function amazonSearch(keywords: string): string {
+	return `https://www.amazon.com/s?k=${encodeURIComponent(keywords)}&tag=${AMAZON_TAG}`;
+}
+
+export type AffiliateItem = {
+	label: string;
+	url: string;
+	note?: string;
+};

--- a/src/lib/components/AffiliateBox.svelte
+++ b/src/lib/components/AffiliateBox.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+	import { AMAZON_DISCLOSURE, type AffiliateItem } from '$lib/affiliate';
+
+	export let heading: string;
+	export let intro: string;
+	export let items: AffiliateItem[];
+</script>
+
+<aside class="affiliate" aria-label="Recommended products">
+	<h3>{heading}</h3>
+	<p class="intro">{intro}</p>
+	<ul>
+		{#each items as item}
+			<li>
+				<a href={item.url} target="_blank" rel="nofollow sponsored noopener">{item.label}</a>{#if item.note}<span
+						class="note"
+					>
+						— {item.note}</span
+					>{/if}
+			</li>
+		{/each}
+	</ul>
+	<p class="disclosure">{AMAZON_DISCLOSURE}</p>
+</aside>
+
+<style>
+	.affiliate {
+		margin: 24px auto;
+		max-width: 1200px;
+		padding: 16px 20px;
+		border: 1px solid var(--bg-3);
+		border-radius: 8px;
+		background-color: var(--bg-2);
+		color: var(--fg-1);
+	}
+
+	.affiliate h3 {
+		margin: 0 0 8px;
+	}
+
+	.intro {
+		margin: 0 0 12px;
+	}
+
+	.affiliate ul {
+		margin: 0 0 12px;
+		padding-left: 20px;
+	}
+
+	.affiliate li {
+		margin-bottom: 6px;
+	}
+
+	.note {
+		color: var(--fg-2);
+	}
+
+	.disclosure {
+		margin: 0;
+		font-size: 0.8rem;
+		color: var(--fg-2);
+	}
+</style>

--- a/src/routes/key-generation/+page.svelte
+++ b/src/routes/key-generation/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import SeoHead from '$lib/components/SeoHead.svelte';
 	import AdUnit from '$lib/components/AdUnit.svelte';
+	import AffiliateBox from '$lib/components/AffiliateBox.svelte';
+	import { amazonSearch } from '$lib/affiliate';
 	import { t } from 'svelte-i18n';
 	import {
 		deriveKeysFromNumericInput,
@@ -144,6 +146,23 @@
 		store your private key, as it is critical for accessing your cryptocurrency assets.
 	</p>
 </div>
+
+<AffiliateBox
+	heading="Storing real crypto? Use a hardware wallet"
+	intro="This tool generates keys in your browser — perfect for learning and testing, but not safe for real funds. For actual crypto, use a hardware wallet that creates and stores keys offline:"
+	items={[
+		{
+			label: 'Ledger hardware wallets',
+			url: amazonSearch('Ledger hardware wallet'),
+			note: 'offline key storage'
+		},
+		{
+			label: 'Trezor hardware wallets',
+			url: amazonSearch('Trezor hardware wallet'),
+			note: 'open-source firmware'
+		}
+	]}
+/>
 
 <AdUnit placement="toolResult" />
 

--- a/src/routes/password-generator/+page.svelte
+++ b/src/routes/password-generator/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import SeoHead from '$lib/components/SeoHead.svelte';
+	import AffiliateBox from '$lib/components/AffiliateBox.svelte';
+	import { amazonSearch } from '$lib/affiliate';
 	import { t } from 'svelte-i18n';
 	import {
 		calculatePasswordStrength,
@@ -111,6 +113,14 @@
 		{/if}
 	{/if}
 </div>
+
+<AffiliateBox
+	heading="Beyond passwords: add a hardware security key"
+	intro="A strong generated password is a great start. For the accounts that matter most, add a hardware security key for phishing-resistant two-factor authentication:"
+	items={[
+		{ label: 'YubiKey security keys', url: amazonSearch('YubiKey security key'), note: 'hardware 2FA' }
+	]}
+/>
 
 <style>
 	.container {


### PR DESCRIPTION
This pull request introduces an affiliate marketing feature focused on Amazon Associates, and integrates an `AffiliateBox` component into key tool pages to recommend relevant hardware products. The main changes include adding Amazon affiliate configuration and utility functions, creating a reusable affiliate product recommendation component, and embedding this component into the key generation and password generator pages with context-appropriate product suggestions.

**Affiliate program integration:**

* Added Amazon Associates configuration, a required disclosure message, and a utility function `amazonSearch` for generating tagged Amazon search links in `src/lib/affiliate.ts`.

**Component development:**

* Created a new `AffiliateBox.svelte` component to display a list of recommended affiliate products with an Amazon disclosure, supporting custom headings, intros, and item lists.

**Feature integration into pages:**

* Embedded `AffiliateBox` into `key-generation/+page.svelte` to recommend hardware crypto wallets, with affiliate links for Ledger and Trezor products. [[1]](diffhunk://#diff-2a768eb17398e00ec42b92316d2c736715e4e35a52168eec60d86bb4af817e1aR4-R5) [[2]](diffhunk://#diff-2a768eb17398e00ec42b92316d2c736715e4e35a52168eec60d86bb4af817e1aR150-R166)
* Embedded `AffiliateBox` into `password-generator/+page.svelte` to recommend YubiKey hardware security keys for two-factor authentication. [[1]](diffhunk://#diff-26e44fdab9f90eb54b061ca6265964a0123086c313ca92f58145b97417068c71R3-R4) [[2]](diffhunk://#diff-26e44fdab9f90eb54b061ca6265964a0123086c313ca92f58145b97417068c71R117-R124)