### PR TITLE
Amazon 어필리에이트 도입 및 주요 도구 페이지 추천 박스 배치

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,6 +2,8 @@
 	import SeoHead from '$lib/components/SeoHead.svelte';
 	import AdUnit from '$lib/components/AdUnit.svelte';
 	import { t } from 'svelte-i18n';
+	import AffiliateBox from '$lib/components/AffiliateBox.svelte';
+	import { amazonSearch } from '$lib/affiliate';
 	import './+page.css';
 
 	type ToolItem = {
@@ -177,4 +179,21 @@
 			</div>
 		{/each}
 	</section>
+
+	<AffiliateBox
+		heading="Sharpen your security and dev skills"
+		intro="Every TxtWizard tool runs entirely in your browser. To go deeper on the security and encoding topics these tools touch, start here:"
+		items={[
+			{
+				label: 'Applied cryptography books',
+				url: amazonSearch('applied cryptography book'),
+				note: 'security fundamentals'
+			},
+			{
+				label: 'YubiKey security keys',
+				url: amazonSearch('YubiKey security key'),
+				note: 'hardware 2FA'
+			}
+		]}
+	/>
 </main>

--- a/src/routes/compression/+page.svelte
+++ b/src/routes/compression/+page.svelte
@@ -2,6 +2,8 @@
 	import SeoHead from '$lib/components/SeoHead.svelte';
 	import AdUnit from '$lib/components/AdUnit.svelte';
 	import { t } from 'svelte-i18n';
+	import AffiliateBox from '$lib/components/AffiliateBox.svelte';
+	import { amazonSearch } from '$lib/affiliate';
 	import {
 		COMPRESSION_ALGORITHMS,
 		compressText,
@@ -105,6 +107,23 @@
 		<textarea id="hashHex" bind:value={outHexText} rows="4" readonly></textarea>
 	</div>
 </div>
+
+<AffiliateBox
+	heading="Working with large files or backups?"
+	intro="This tool compresses text right in your browser. When you're moving or storing bigger data, faster storage and a solid grasp of compression help:"
+	items={[
+		{
+			label: 'Portable SSD drives',
+			url: amazonSearch('portable SSD external drive'),
+			note: 'fast external storage'
+		},
+		{
+			label: 'Data compression & algorithms books',
+			url: amazonSearch('data compression algorithms book'),
+			note: 'go deeper'
+		}
+	]}
+/>
 
 <AdUnit placement="toolResult" />
 

--- a/src/routes/decryption/+page.svelte
+++ b/src/routes/decryption/+page.svelte
@@ -3,6 +3,8 @@
 	import AdUnit from '$lib/components/AdUnit.svelte';
 	import { t } from 'svelte-i18n';
 	import { trackToolsUsageEvent } from '$lib/utils/analytics';
+	import AffiliateBox from '$lib/components/AffiliateBox.svelte';
+	import { amazonSearch } from '$lib/affiliate';
 	import {
 		convertEncoding,
 		decryptText,
@@ -210,6 +212,23 @@
 		>
 	</div>
 </div>
+
+<AffiliateBox
+	heading="Learning how encryption works?"
+	intro="This tool decrypts AES ciphertext in your browser. To go from experimenting with crypto to securing real data, these are a solid next step:"
+	items={[
+		{
+			label: 'YubiKey security keys',
+			url: amazonSearch('YubiKey security key'),
+			note: 'hardware 2FA'
+		},
+		{
+			label: 'Applied cryptography books',
+			url: amazonSearch('applied cryptography book'),
+			note: 'learn the fundamentals'
+		}
+	]}
+/>
 
 <AdUnit placement="toolResult" />
 

--- a/src/routes/encryption/+page.svelte
+++ b/src/routes/encryption/+page.svelte
@@ -3,6 +3,8 @@
 	import AdUnit from '$lib/components/AdUnit.svelte';
 	import { t } from 'svelte-i18n';
 	import { trackToolsUsageEvent } from '$lib/utils/analytics';
+	import AffiliateBox from '$lib/components/AffiliateBox.svelte';
+	import { amazonSearch } from '$lib/affiliate';
 	import {
 		AES_ALGORITHM_CONFIG,
 		convertEncoding,
@@ -243,6 +245,23 @@
 		>
 	</div>
 </div>
+
+<AffiliateBox
+	heading="Serious about protecting real data?"
+	intro="This tool encrypts text locally in your browser — perfect for learning AES. To secure actual accounts and secrets, a hardware security key adds phishing-resistant protection:"
+	items={[
+		{
+			label: 'YubiKey security keys',
+			url: amazonSearch('YubiKey security key'),
+			note: 'hardware 2FA'
+		},
+		{
+			label: 'Applied cryptography books',
+			url: amazonSearch('applied cryptography book'),
+			note: 'learn the fundamentals'
+		}
+	]}
+/>
 
 <AdUnit placement="toolResult" />
 

--- a/src/routes/qrcode/+page.svelte
+++ b/src/routes/qrcode/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import SeoHead from '$lib/components/SeoHead.svelte';
 	import { t } from 'svelte-i18n';
+	import AffiliateBox from '$lib/components/AffiliateBox.svelte';
+	import { amazonSearch } from '$lib/affiliate';
 	import { generateQRCodeDataUrl } from '$lib/utils/qrcode';
 
 	let qrInputText = '';
@@ -42,6 +44,23 @@
 		{/if}
 	</div>
 </div>
+
+<AffiliateBox
+	heading="Printing or scanning QR codes often?"
+	intro="This tool generates QR codes right in your browser. If you print labels or scan codes regularly, these make it easier:"
+	items={[
+		{
+			label: 'Label printers',
+			url: amazonSearch('label printer'),
+			note: 'print QR labels'
+		},
+		{
+			label: 'Barcode & QR scanners',
+			url: amazonSearch('QR code barcode scanner'),
+			note: 'fast scanning'
+		}
+	]}
+/>
 
 <div class="description">
 	<h2>What is a QR Code?</h2>


### PR DESCRIPTION
## 개요

Amazon Associates 어필리에이트를 도입하고, 트래픽·상품 관련성이 높은 도구 페이지에 추천 박스를 배치합니다. Associate 계정(`txtwizard-20`)이 승인되어 실제 커미션 귀속이 가능한 상태입니다.

모든 링크는 브라우저 전용 도구의 성격에 맞게 각 도구 맥락과 자연스럽게 연결되는 상품만 노출하며, Amazon Operating Agreement가 요구하는 공시문("As an Amazon Associate…")을 항상 함께 표시합니다.

## 배치 근거 (GA4 데이터)

BigQuery export 초기 데이터에서 페이지별 방문을 확인해, **트래픽 × 상품 관련성**이 높은 곳에 우선 배치했습니다. (표본이 작아 방향성 신호로만 사용)

| 페이지 | 방문(초기) | 배치 상품 |
|---|---|---|
| 홈 `/` | 1위 | 암호학 책 · YubiKey |
| `/compression` | 2위 | 외장 SSD · 데이터 압축 책 |
| `/encryption` | 있음 | YubiKey · 암호학 책 |
| `/decryption` | 있음 | YubiKey · 암호학 책 |
| `/qrcode` | 있음 | 라벨 프린터 · QR 스캐너 |
| `/key-generation` | 있음 | 하드웨어 지갑 |
| `/password-generator` | 있음 | YubiKey |

> 관련 상품이 없는 순수 텍스트 유틸(`timestamp`, `regex`, `json` 등)은 억지 배치 대신 제외했습니다.

## 변경 구조

```mermaid
flowchart LR
  A["src/lib/affiliate.ts<br/>AMAZON_TAG · amazonSearch · 공시문"] --> B["AffiliateBox.svelte<br/>heading · intro · items · 공시"]
  B --> C["도구 페이지 7개<br/>맥락별 상품 items 주입"]
```

- `src/lib/affiliate.ts` — 태그(`txtwizard-20`), 검색 링크 빌더, 필수 공시 상수
- `src/lib/components/AffiliateBox.svelte` — 재사용 박스. 링크에 `rel="nofollow sponsored noopener"`
- 도구 페이지 7개 — 각 맥락에 맞는 상품을 `amazonSearch()` 검색 링크로 주입

## 검증

- `npm run check` — 0 errors / 0 warnings
- `npm run build` — 성공, 프리렌더 HTML 7개 페이지 전부 링크·공시 정상 출력 확인

## 후속 (별도)

- 검색 링크 → SiteStripe 특정 상품(ASIN) 링크로 교체 시 전환율 개선
- 홈 박스는 구매 의도가 약한 맥락이라 반응 저조 시 최우선 제거 후보
