### PR TITLE
데이터 기반 수익 개선: 계측 공백 해소·크로스링크·광고 배치·봇 필터링

### DIFF
--- a/src/lib/ads.ts
+++ b/src/lib/ads.ts
@@ -21,7 +21,14 @@ export const AD_SLOTS = {
 	// look here right after clicking generate/convert). Reused across tools.
 	toolResult: '8839886302',
 	// Inline unit on the home page.
-	homeInline: '7526804635'
+	homeInline: '7526804635',
+	// Placed inside the long-form explainer copy further down a tool page.
+	// Worth having only where visitors actually read: BigQuery shows
+	// /compression at ~64s per user and /decryption, /key-generation,
+	// /encryption at 25-35s, versus ~8s on the home page.
+	// TODO: create a responsive Display unit in AdSense and paste its slot id.
+	// Until then this renders nothing in production.
+	articleInline: ''
 } as const;
 
 export type AdPlacement = keyof typeof AD_SLOTS;

--- a/src/lib/components/AdUnit.svelte
+++ b/src/lib/components/AdUnit.svelte
@@ -1,16 +1,27 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onMount, tick } from 'svelte';
 	import { dev } from '$app/environment';
 	import { AD_CLIENT, getAdSlot, type AdPlacement } from '$lib/ads';
+	import { isLikelyAutomated } from '$lib/utils/analytics';
 
 	export let placement: AdPlacement;
 	export let label = 'Advertisement';
 
 	const slot = getAdSlot(placement);
-	const configured = slot.length > 0;
+	const hasSlot = slot.length > 0;
 
-	onMount(() => {
-		if (!configured) return;
+	// The <ins> is mounted client-side only, so `isLikelyAutomated()` can read
+	// `navigator` first. Keeping the unit out of automated sessions avoids
+	// serving impressions to traffic that would count as invalid.
+	let render = false;
+
+	onMount(async () => {
+		if (!hasSlot || isLikelyAutomated()) return;
+
+		render = true;
+		// Wait for the <ins> to be in the DOM before AdSense scans for it.
+		await tick();
+
 		try {
 			const w = window as unknown as { adsbygoogle?: unknown[] };
 			(w.adsbygoogle = w.adsbygoogle || []).push({});
@@ -20,7 +31,7 @@
 	});
 </script>
 
-{#if configured}
+{#if render}
 	<aside class="ad-slot" aria-label={label}>
 		<ins
 			class="adsbygoogle"
@@ -31,7 +42,7 @@
 			data-full-width-responsive="true"
 		></ins>
 	</aside>
-{:else if dev}
+{:else if dev && !hasSlot}
 	<aside class="ad-slot ad-placeholder" aria-label="Ad placeholder">
 		<span>Ad slot &ldquo;{placement}&rdquo; — set its id in src/lib/ads.ts</span>
 	</aside>

--- a/src/lib/components/RelatedTools.svelte
+++ b/src/lib/components/RelatedTools.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+	import { t } from 'svelte-i18n';
+	import { getRelatedTools } from '$lib/related-tools';
+	import { trackToolsUsageEvent } from '$lib/utils/analytics';
+
+	/** Route name of the current tool, e.g. "compression". */
+	export let tool: string;
+	export let heading = 'Continue with';
+
+	$: related = getRelatedTools(tool);
+
+	function handleClick(targetHref: string) {
+		trackToolsUsageEvent(tool, 'related_tool_click', { target_tool: targetHref });
+	}
+</script>
+
+{#if related.length > 0}
+	<nav class="related" aria-label="Related tools">
+		<h3>{heading}</h3>
+		<ul>
+			{#each related as item}
+				<li>
+					<a href={item.href} on:click={() => handleClick(item.href)}>
+						<span class="name">{$t(item.labelKey)}</span>
+						<span class="blurb">{item.blurb}</span>
+					</a>
+				</li>
+			{/each}
+		</ul>
+	</nav>
+{/if}
+
+<style>
+	.related {
+		margin: 24px auto;
+		max-width: 1200px;
+	}
+
+	.related h3 {
+		margin: 0 0 12px;
+	}
+
+	.related ul {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+		gap: 12px;
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	.related a {
+		display: block;
+		height: 100%;
+		padding: 14px 16px;
+		border: 1px solid var(--bg-3);
+		border-radius: 8px;
+		background-color: var(--bg-2);
+		color: inherit;
+		text-decoration: none;
+	}
+
+	.related a:hover,
+	.related a:focus-visible {
+		border-color: var(--link);
+	}
+
+	.name {
+		display: block;
+		font-weight: 700;
+		color: var(--link);
+	}
+
+	.blurb {
+		display: block;
+		margin-top: 4px;
+		font-size: 0.9rem;
+		color: var(--fg-2);
+	}
+</style>

--- a/src/lib/related-tools.ts
+++ b/src/lib/related-tools.ts
@@ -1,0 +1,97 @@
+// Cross-links between tools.
+//
+// The first week of BigQuery data showed 1.19 page views per session and 84%
+// single-page sessions: visitors land on one tool from search and leave. These
+// curated links follow real workflows (compress -> inspect the Base64 output,
+// encrypt -> decrypt, generate a key -> use it) so the next click is useful
+// rather than a generic tool dump.
+
+export type RelatedTool = {
+	href: string;
+	/** i18n key, same keys the nav uses. */
+	labelKey: string;
+	/** Short reason to click through. */
+	blurb: string;
+};
+
+const TOOL: Record<string, RelatedTool> = {
+	analyzer: {
+		href: '/analyzer',
+		labelKey: 'analyzer',
+		blurb: 'count characters, words, and byte size'
+	},
+	comparison: {
+		href: '/comparison',
+		labelKey: 'comparison',
+		blurb: 'diff two texts and drop duplicate lines'
+	},
+	compression: {
+		href: '/compression',
+		labelKey: 'compression',
+		blurb: 'shrink text with GZIP, Deflate, or ZIP'
+	},
+	dateCalculator: {
+		href: '/date-calculator',
+		labelKey: 'date-calculator',
+		blurb: 'add, subtract, and diff calendar dates'
+	},
+	decryption: { href: '/decryption', labelKey: 'decryption', blurb: 'decrypt AES or DES payloads' },
+	encoding: {
+		href: '/encoding-decoding',
+		labelKey: 'encoding',
+		blurb: 'convert Base64, Hex, URL, and HTML encodings'
+	},
+	encryption: {
+		href: '/encryption',
+		labelKey: 'encryption',
+		blurb: 'encrypt text with AES or DES'
+	},
+	hashing: {
+		href: '/hashing',
+		labelKey: 'hashing',
+		blurb: 'hash with MD5, SHA-1, SHA-256, or SHA-512'
+	},
+	json: { href: '/json', labelKey: 'json-tool', blurb: 'format, validate, and query JSON' },
+	jwt: { href: '/jwt', labelKey: 'jwt', blurb: 'decode, verify, and sign JSON Web Tokens' },
+	keygen: {
+		href: '/key-generation',
+		labelKey: 'keygen',
+		blurb: 'generate BTC and ETH key pairs'
+	},
+	minifier: { href: '/minifier', labelKey: 'code-minifier', blurb: 'minify JS, CSS, and HTML' },
+	password: {
+		href: '/password-generator',
+		labelKey: 'password-generator',
+		blurb: 'build strong random passwords'
+	},
+	qrcode: { href: '/qrcode', labelKey: 'qr-code-gen', blurb: 'turn text or a URL into a QR code' },
+	regex: { href: '/regex', labelKey: 'regex-tool', blurb: 'test regular expressions live' },
+	timestamp: {
+		href: '/timestamp',
+		labelKey: 'timestamp-tool',
+		blurb: 'convert Unix timestamps and dates'
+	}
+};
+
+const RELATED: Record<string, RelatedTool[]> = {
+	analyzer: [TOOL.comparison, TOOL.minifier, TOOL.encoding],
+	comparison: [TOOL.analyzer, TOOL.json, TOOL.minifier],
+	compression: [TOOL.encoding, TOOL.hashing, TOOL.analyzer],
+	'date-calculator': [TOOL.timestamp, TOOL.analyzer, TOOL.comparison],
+	decryption: [TOOL.encryption, TOOL.encoding, TOOL.hashing],
+	'encoding-decoding': [TOOL.compression, TOOL.hashing, TOOL.jwt],
+	encryption: [TOOL.decryption, TOOL.keygen, TOOL.hashing],
+	hashing: [TOOL.encryption, TOOL.encoding, TOOL.password],
+	json: [TOOL.minifier, TOOL.comparison, TOOL.jwt],
+	jwt: [TOOL.encoding, TOOL.hashing, TOOL.timestamp],
+	'key-generation': [TOOL.encryption, TOOL.hashing, TOOL.password],
+	minifier: [TOOL.json, TOOL.compression, TOOL.analyzer],
+	'password-generator': [TOOL.keygen, TOOL.hashing, TOOL.encryption],
+	qrcode: [TOOL.encoding, TOOL.analyzer, TOOL.json],
+	regex: [TOOL.comparison, TOOL.analyzer, TOOL.json],
+	timestamp: [TOOL.dateCalculator, TOOL.jwt, TOOL.json]
+};
+
+export function getRelatedTools(toolName: string): RelatedTool[] {
+	return RELATED[toolName] ?? [];
+}

--- a/src/lib/utils/analytics.ts
+++ b/src/lib/utils/analytics.ts
@@ -1,9 +1,79 @@
-export function trackToolsUsageEvent(toolName: string, eventName: string, params: Record<string, any>) {
-    if (window.gtag) {
-        window.gtag('event', 'tools_usage', {
-            tool_name: toolName,
-            event_name: eventName,
-            ...params,
-        });
-    }
+// Client-side analytics helpers.
+//
+// Two jobs:
+//   1. Send `tools_usage` custom events (tool_name / event_name + params) to GA4.
+//   2. Flag automated (headless / driver-controlled) sessions so they can be
+//      segmented out of GA4 reports and excluded from manual ad units.
+//
+// Why (2): the first week of BigQuery data showed ~44% of users producing zero
+// engagement time and zero `user_engagement` events — a single-city, single
+// browser, direct-traffic pattern. GA4's built-in IAB bot list did not catch
+// it. Detection here is deliberately conservative: only signals that are
+// unambiguous for automation are used, so no real visitor gets dropped.
+// Cleverly disguised bots will still slip through client-side detection; the
+// BigQuery-side engagement filter is the backstop for analysis.
+
+const BOT_UA_PATTERN = /bot|crawl|spider|headless|phantomjs|puppeteer|playwright|selenium/i;
+
+let cachedAutomated: boolean | null = null;
+
+export function isLikelyAutomated(): boolean {
+	if (typeof navigator === 'undefined') return false;
+	if (cachedAutomated !== null) return cachedAutomated;
+
+	const nav = navigator as Navigator & { webdriver?: boolean };
+	cachedAutomated = nav.webdriver === true || BOT_UA_PATTERN.test(nav.userAgent ?? '');
+
+	return cachedAutomated;
+}
+
+// Tag the session once so GA4 explorations and BigQuery can segment on it.
+// Runs from the root layout on mount.
+export function initTrafficQuality() {
+	if (typeof window === 'undefined' || !window.gtag) return;
+
+	window.gtag('set', 'user_properties', {
+		traffic_quality: isLikelyAutomated() ? 'automated' : 'human'
+	});
+}
+
+export function trackToolsUsageEvent(
+	toolName: string,
+	eventName: string,
+	params: Record<string, any> = {}
+) {
+	if (typeof window === 'undefined' || !window.gtag) return;
+
+	window.gtag('event', 'tools_usage', {
+		tool_name: toolName,
+		event_name: eventName,
+		automated: isLikelyAutomated() ? 1 : 0,
+		...params
+	});
+}
+
+// Fire at most one event per `wait` ms per key. Used by tools that produce
+// results reactively while typing (analyzer, encoding-decoding, jwt) so a
+// single edit session does not emit hundreds of events.
+const debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+export function trackToolsUsageDebounced(
+	toolName: string,
+	eventName: string,
+	params: Record<string, any> = {},
+	wait = 1500
+) {
+	if (typeof window === 'undefined') return;
+
+	const key = `${toolName}:${eventName}`;
+	const existing = debounceTimers.get(key);
+	if (existing) clearTimeout(existing);
+
+	debounceTimers.set(
+		key,
+		setTimeout(() => {
+			debounceTimers.delete(key);
+			trackToolsUsageEvent(toolName, eventName, params);
+		}, wait)
+	);
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import { page } from '$app/stores';
 	import { t } from 'svelte-i18n';
+	import { initTrafficQuality } from '$lib/utils/analytics';
+
+	onMount(initTrafficQuality);
 
 	export let data: {
 		buildInfo: {

--- a/src/routes/analyzer/+page.svelte
+++ b/src/routes/analyzer/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import SeoHead from '$lib/components/SeoHead.svelte';
+	import RelatedTools from '$lib/components/RelatedTools.svelte';
 	import { t } from 'svelte-i18n';
+	import { trackToolsUsageDebounced } from '$lib/utils/analytics';
 	import { analyzeText } from '$lib/utils/analyzer';
 
 	let inputText = '';
@@ -21,6 +23,18 @@
 		sentenceCount = result.sentenceCount;
 		uniqueWordCount = result.uniqueWordCount;
 		byteSize = result.byteSize;
+
+		// The analyzer has no submit button — results update while typing. Fire a
+		// single debounced event per editing burst, and never for the empty
+		// initial state, so a page load alone does not count as usage.
+		if (inputText.length > 0) {
+			trackToolsUsageDebounced('analyzer', 'analyze', {
+				input_text_length: inputText.length,
+				word_count: wordCount,
+				line_count: lineCount,
+				byte_size: byteSize
+			});
+		}
 	}
 
 	const pageTitle = 'TxtWizard | Text Analyzer Tool';
@@ -49,6 +63,8 @@
 		<p>{$t('byte-size')}: {byteSize} bytes</p>
 	</div>
 </div>
+
+<RelatedTools tool="analyzer" />
 
 <style>
 	.container {

--- a/src/routes/comparison/+page.svelte
+++ b/src/routes/comparison/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import SeoHead from '$lib/components/SeoHead.svelte';
+	import RelatedTools from '$lib/components/RelatedTools.svelte';
 	import { t } from 'svelte-i18n';
+	import { trackToolsUsageEvent } from '$lib/utils/analytics';
 	import {
 		compareTexts as buildDiff,
 		deduplicateText as deduplicateEntries,
@@ -16,10 +18,21 @@
 
 	function compareTexts() {
 		diff = buildDiff(text1, text2);
+		trackToolsUsageEvent('comparison', 'compare', {
+			text1_length: text1.length,
+			text2_length: text2.length,
+			non_empty: text1.length > 0 && text2.length > 0 ? 1 : 0
+		});
 	}
 
 	function deduplicateText() {
 		deduplicatedText = deduplicateEntries(textToDeduplicate, deduplicationType);
+		trackToolsUsageEvent('comparison', 'deduplicate', {
+			deduplication_type: deduplicationType,
+			input_text_length: textToDeduplicate.length,
+			output_text_length: deduplicatedText.length,
+			non_empty: textToDeduplicate.length > 0 ? 1 : 0
+		});
 	}
 
 	const pageTitle = 'TxtWizard | Text Comparison and Duplicate Removal Tool';
@@ -72,6 +85,8 @@
 		<textarea readonly rows="6">{deduplicatedText}</textarea>
 	</div>
 </div>
+
+<RelatedTools tool="comparison" />
 
 <style>
 	.container {

--- a/src/routes/compression/+page.svelte
+++ b/src/routes/compression/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import SeoHead from '$lib/components/SeoHead.svelte';
 	import AdUnit from '$lib/components/AdUnit.svelte';
+	import RelatedTools from '$lib/components/RelatedTools.svelte';
 	import { t } from 'svelte-i18n';
 	import { trackToolsUsageEvent } from '$lib/utils/analytics';
 	import AffiliateBox from '$lib/components/AffiliateBox.svelte';
@@ -122,6 +123,8 @@
 	</div>
 </div>
 
+<AdUnit placement="toolResult" />
+
 <AffiliateBox
 	heading="Working with large files or backups?"
 	intro="This tool compresses text right in your browser. When you're moving or storing bigger data, faster storage and a solid grasp of compression help:"
@@ -139,7 +142,7 @@
 	]}
 />
 
-<AdUnit placement="toolResult" />
+<RelatedTools tool="compression" heading="Next steps with your compressed output" />
 
 <div class="description">
 	<h3>About the Compression Tool</h3>
@@ -157,6 +160,8 @@
 		honest view of the formats it actually generates, with outputs available in both Base64 and Hex.
 	</p>
 </div>
+
+<AdUnit placement="articleInline" />
 
 <div class="description">
 	<h3>Compression Algorithms Supported</h3>

--- a/src/routes/compression/+page.svelte
+++ b/src/routes/compression/+page.svelte
@@ -2,6 +2,7 @@
 	import SeoHead from '$lib/components/SeoHead.svelte';
 	import AdUnit from '$lib/components/AdUnit.svelte';
 	import { t } from 'svelte-i18n';
+	import { trackToolsUsageEvent } from '$lib/utils/analytics';
 	import AffiliateBox from '$lib/components/AffiliateBox.svelte';
 	import { amazonSearch } from '$lib/affiliate';
 	import {
@@ -24,10 +25,23 @@
 	const algorithms = COMPRESSION_ALGORITHMS;
 
 	function doCompress() {
-		const result = compressText(targetPlainText, selectedAlgorithm);
-		outHashText = result.base64;
-		outHexText = result.hex;
-		metrics = result.metrics;
+		try {
+			const result = compressText(targetPlainText, selectedAlgorithm);
+			outHashText = result.base64;
+			outHexText = result.hex;
+			metrics = result.metrics;
+		} catch (error) {
+			console.error('Error during compression:', error);
+		} finally {
+			trackToolsUsageEvent('compression', 'compress', {
+				algorithm: selectedAlgorithm,
+				original_size: metrics.originalSize,
+				output_size: metrics.outputSize,
+				compression_ratio: metrics.compressionRatio,
+				input_text_length: targetPlainText.length,
+				non_empty: targetPlainText.length > 0 ? 1 : 0
+			});
+		}
 	}
 
 	const pageTitle = 'TxtWizard | Free Online Compression Tool - GZIP, Deflate, ZIP';

--- a/src/routes/date-calculator/+page.svelte
+++ b/src/routes/date-calculator/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import SeoHead from '$lib/components/SeoHead.svelte';
+	import RelatedTools from '$lib/components/RelatedTools.svelte';
 	import { t } from 'svelte-i18n';
+	import { trackToolsUsageEvent } from '$lib/utils/analytics';
 	import {
 		addOrSubtractDays as calculateShiftedDate,
 		calculateDateDifference as getDateDifference
@@ -16,6 +18,10 @@
 
 	function calculateDateDifference() {
 		const result = getDateDifference(startDate, endDate);
+		trackToolsUsageEvent('date-calculator', 'date_difference', {
+			succeeded: result === null ? 0 : 1
+		});
+
 		if (result === null) {
 			dayDifference = 0;
 			alert($t('invalid_date_format'));
@@ -27,6 +33,11 @@
 
 	function addOrSubtractDays() {
 		const result = calculateShiftedDate(baseDate, daysToAdd);
+		trackToolsUsageEvent('date-calculator', 'shift_date', {
+			days_to_add: daysToAdd,
+			succeeded: result === null ? 0 : 1
+		});
+
 		if (result === null) {
 			calculatedDate = '';
 			alert($t('invalid_date_format'));
@@ -88,6 +99,8 @@
 			{/if}
 		</div>
 	</section>
+
+	<RelatedTools tool="date-calculator" />
 </main>
 
 <style>

--- a/src/routes/decryption/+page.svelte
+++ b/src/routes/decryption/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import SeoHead from '$lib/components/SeoHead.svelte';
 	import AdUnit from '$lib/components/AdUnit.svelte';
+	import RelatedTools from '$lib/components/RelatedTools.svelte';
 	import { t } from 'svelte-i18n';
 	import { trackToolsUsageEvent } from '$lib/utils/analytics';
 	import AffiliateBox from '$lib/components/AffiliateBox.svelte';
@@ -213,6 +214,8 @@
 	</div>
 </div>
 
+<AdUnit placement="toolResult" />
+
 <AffiliateBox
 	heading="Learning how encryption works?"
 	intro="This tool decrypts AES ciphertext in your browser. To go from experimenting with crypto to securing real data, these are a solid next step:"
@@ -230,7 +233,7 @@
 	]}
 />
 
-<AdUnit placement="toolResult" />
+<RelatedTools tool="decryption" heading="Next steps with your plaintext" />
 
 <div class="description">
 	<h3>What is Decryption?</h3>

--- a/src/routes/encoding-decoding/+page.svelte
+++ b/src/routes/encoding-decoding/+page.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 	import SeoHead from '$lib/components/SeoHead.svelte';
 	import AdUnit from '$lib/components/AdUnit.svelte';
+	import RelatedTools from '$lib/components/RelatedTools.svelte';
 	import { t } from 'svelte-i18n';
+	import { trackToolsUsageDebounced } from '$lib/utils/analytics';
 	import { onMount } from 'svelte';
 	import { Buffer } from 'buffer';
 	import { calculateRows, detectAndConvertInput } from '$lib/utils/encoding';
@@ -47,6 +49,16 @@
 			htmlEncodeBytes = Buffer.byteLength(htmlEncode, 'utf-8');
 		} catch (error) {
 			console.error('Error processing input', error);
+		}
+
+		// Conversion happens while typing, and onMount runs it once with an empty
+		// input — debounce and skip the empty case so events reflect real usage.
+		if (userInput.length > 0) {
+			trackToolsUsageDebounced('encoding-decoding', 'convert', {
+				detected_encoding: detectedEncoding,
+				input_text_length: userInput.length,
+				plain_text_bytes: plainTextBytes
+			});
 		}
 	}
 
@@ -165,6 +177,8 @@
 </div>
 
 <AdUnit placement="toolResult" />
+
+<RelatedTools tool="encoding-decoding" />
 
 <div class="description">
 	<h3>About the Text Encoding and Decoding Tool</h3>

--- a/src/routes/encryption/+page.svelte
+++ b/src/routes/encryption/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import SeoHead from '$lib/components/SeoHead.svelte';
 	import AdUnit from '$lib/components/AdUnit.svelte';
+	import RelatedTools from '$lib/components/RelatedTools.svelte';
 	import { t } from 'svelte-i18n';
 	import { trackToolsUsageEvent } from '$lib/utils/analytics';
 	import AffiliateBox from '$lib/components/AffiliateBox.svelte';
@@ -246,6 +247,8 @@
 	</div>
 </div>
 
+<AdUnit placement="toolResult" />
+
 <AffiliateBox
 	heading="Serious about protecting real data?"
 	intro="This tool encrypts text locally in your browser — perfect for learning AES. To secure actual accounts and secrets, a hardware security key adds phishing-resistant protection:"
@@ -263,7 +266,7 @@
 	]}
 />
 
-<AdUnit placement="toolResult" />
+<RelatedTools tool="encryption" heading="Next steps with your ciphertext" />
 
 <div class="description">
 	<h3>What is Encryption?</h3>

--- a/src/routes/hashing/+page.svelte
+++ b/src/routes/hashing/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import SeoHead from '$lib/components/SeoHead.svelte';
+	import RelatedTools from '$lib/components/RelatedTools.svelte';
 	import AdUnit from '$lib/components/AdUnit.svelte';
 	import { t } from 'svelte-i18n';
 	import { Buffer } from 'buffer';
@@ -204,6 +205,7 @@
 			<li>BLAKE2 and BLAKE3 offer excellent performance for high-speed applications</li>
 		</ul>
 	</section>
+	<RelatedTools tool="hashing" />
 </main>
 
 <style>

--- a/src/routes/json/+page.svelte
+++ b/src/routes/json/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import SeoHead from '$lib/components/SeoHead.svelte';
+	import RelatedTools from '$lib/components/RelatedTools.svelte';
 	import { t } from 'svelte-i18n';
 	import { trackToolsUsageEvent } from '$lib/utils/analytics';
 	import {
@@ -185,6 +186,7 @@
 			</li>
 		</ul>
 	</section>
+	<RelatedTools tool="json" />
 </main>
 
 <style>

--- a/src/routes/jwt/+page.svelte
+++ b/src/routes/jwt/+page.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 	import SeoHead from '$lib/components/SeoHead.svelte';
+	import RelatedTools from '$lib/components/RelatedTools.svelte';
 	import { Buffer } from 'buffer';
 	import { t } from 'svelte-i18n';
+	import { trackToolsUsageDebounced, trackToolsUsageEvent } from '$lib/utils/analytics';
 	import {
 		formatJson,
 		generateJwt,
@@ -106,6 +108,13 @@
 			verificationInputMode = 'unknown';
 			parseError = error instanceof Error ? error.message : 'Failed to decode JWT.';
 		}
+
+		// Also runs on every keystroke in the token field — debounce it.
+		trackToolsUsageDebounced('jwt', 'decode', {
+			algorithm: typeof parsed?.header.alg === 'string' ? parsed.header.alg : 'unknown',
+			token_length: token.length,
+			succeeded: parsed ? 1 : 0
+		});
 	}
 
 	function getVerificationInputMode() {
@@ -268,9 +277,19 @@
 			}
 			generatorTone = 'success';
 			decodeToken();
+			trackToolsUsageEvent('jwt', 'generate', {
+				algorithm: generatorAlgorithm,
+				secret_encoding: generatorSecretEncoding,
+				succeeded: 1
+			});
 		} catch (error) {
 			generatorStatus = error instanceof Error ? error.message : 'Failed to generate JWT.';
 			generatorTone = 'danger';
+			trackToolsUsageEvent('jwt', 'generate', {
+				algorithm: generatorAlgorithm,
+				secret_encoding: generatorSecretEncoding,
+				succeeded: 0
+			});
 		}
 	}
 
@@ -288,6 +307,11 @@
 				secretEncoding
 			});
 			verificationResult = result.message;
+			trackToolsUsageEvent('jwt', 'verify', {
+				algorithm: typeof parsed?.header.alg === 'string' ? parsed.header.alg : 'unknown',
+				secret_encoding: secretEncoding,
+				result: result.status
+			});
 			verificationTone =
 				result.status === 'valid'
 					? 'success'
@@ -731,6 +755,8 @@
 		</section>
 	{/if}
 </div>
+
+<RelatedTools tool="jwt" />
 
 <div class="description">
 	<h3>What this JWT tool does</h3>

--- a/src/routes/key-generation/+page.svelte
+++ b/src/routes/key-generation/+page.svelte
@@ -2,7 +2,9 @@
 	import SeoHead from '$lib/components/SeoHead.svelte';
 	import AdUnit from '$lib/components/AdUnit.svelte';
 	import AffiliateBox from '$lib/components/AffiliateBox.svelte';
+	import RelatedTools from '$lib/components/RelatedTools.svelte';
 	import { amazonSearch } from '$lib/affiliate';
+	import { trackToolsUsageEvent } from '$lib/utils/analytics';
 	import { t } from 'svelte-i18n';
 	import {
 		deriveKeysFromNumericInput,
@@ -30,14 +32,22 @@
 
 	function generateKeys() {
 		applyDerivedKeys(generateRandomKeyPair());
+		trackToolsUsageEvent('key-generation', 'generate', { source: 'random' });
 	}
 
 	function updateKeysFromNumericInput() {
+		let ok = 1;
 		try {
 			applyDerivedKeys(deriveKeysFromNumericInput(privateKeyNumeric));
 		} catch (error) {
+			ok = 0;
 			console.error('Invalid numeric private key input:', error);
 		}
+		trackToolsUsageEvent('key-generation', 'derive', {
+			source: 'numeric_input',
+			input_length: privateKeyNumeric.length,
+			succeeded: ok
+		});
 	}
 
 	const pageTitle = 'TxtWizard | Free Online BTC and ETH Key Generation Tool';
@@ -147,6 +157,8 @@
 	</p>
 </div>
 
+<AdUnit placement="toolResult" />
+
 <AffiliateBox
 	heading="Storing real crypto? Use a hardware wallet"
 	intro="This tool generates keys in your browser — perfect for learning and testing, but not safe for real funds. For actual crypto, use a hardware wallet that creates and stores keys offline:"
@@ -164,7 +176,7 @@
 	]}
 />
 
-<AdUnit placement="toolResult" />
+<RelatedTools tool="key-generation" heading="Next steps with your key pair" />
 
 <div class="description">
 	<h3>Outputs:</h3>

--- a/src/routes/minifier/+page.svelte
+++ b/src/routes/minifier/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import SeoHead from '$lib/components/SeoHead.svelte';
+	import RelatedTools from '$lib/components/RelatedTools.svelte';
 	import { t } from 'svelte-i18n';
 	import { trackToolsUsageEvent } from '$lib/utils/analytics';
 	import {
@@ -142,6 +143,7 @@
 			</li>
 		</ul>
 	</section>
+	<RelatedTools tool="minifier" />
 </main>
 
 <style>

--- a/src/routes/password-generator/+page.svelte
+++ b/src/routes/password-generator/+page.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 	import SeoHead from '$lib/components/SeoHead.svelte';
 	import AffiliateBox from '$lib/components/AffiliateBox.svelte';
+	import RelatedTools from '$lib/components/RelatedTools.svelte';
 	import { amazonSearch } from '$lib/affiliate';
+	import { trackToolsUsageEvent } from '$lib/utils/analytics';
 	import { t } from 'svelte-i18n';
 	import {
 		calculatePasswordStrength,
@@ -48,11 +50,22 @@
 			strengthColor = '';
 			errorMessage = error instanceof Error ? error.message : 'Failed to generate password.';
 		}
+
+		trackToolsUsageEvent('password-generator', 'generate', {
+			length: passwordLength,
+			include_uppercase: includeUppercase ? 1 : 0,
+			include_lowercase: includeLowercase ? 1 : 0,
+			include_numbers: includeNumbers ? 1 : 0,
+			include_symbols: includeSymbols ? 1 : 0,
+			strength,
+			succeeded: generatedPassword.length > 0 ? 1 : 0
+		});
 	}
 
 	function copyToClipboard() {
 		if (!generatedPassword) return;
 		navigator.clipboard.writeText(generatedPassword);
+		trackToolsUsageEvent('password-generator', 'copy', { length: generatedPassword.length });
 	}
 
 	const pageTitle = 'TxtWizard | Random Password Generator';
@@ -118,9 +131,15 @@
 	heading="Beyond passwords: add a hardware security key"
 	intro="A strong generated password is a great start. For the accounts that matter most, add a hardware security key for phishing-resistant two-factor authentication:"
 	items={[
-		{ label: 'YubiKey security keys', url: amazonSearch('YubiKey security key'), note: 'hardware 2FA' }
+		{
+			label: 'YubiKey security keys',
+			url: amazonSearch('YubiKey security key'),
+			note: 'hardware 2FA'
+		}
 	]}
 />
+
+<RelatedTools tool="password-generator" />
 
 <style>
 	.container {

--- a/src/routes/qrcode/+page.svelte
+++ b/src/routes/qrcode/+page.svelte
@@ -2,18 +2,32 @@
 	import SeoHead from '$lib/components/SeoHead.svelte';
 	import { t } from 'svelte-i18n';
 	import AffiliateBox from '$lib/components/AffiliateBox.svelte';
+	import RelatedTools from '$lib/components/RelatedTools.svelte';
 	import { amazonSearch } from '$lib/affiliate';
+	import { trackToolsUsageEvent } from '$lib/utils/analytics';
 	import { generateQRCodeDataUrl } from '$lib/utils/qrcode';
 
 	let qrInputText = '';
 	let qrCodeDataUrl = '';
 
 	async function generateQRCode() {
+		let ok = 1;
 		try {
 			qrCodeDataUrl = await generateQRCodeDataUrl(qrInputText);
 		} catch (error) {
+			ok = 0;
 			console.error('Error generating QR code:', error);
 		}
+		trackToolsUsageEvent('qrcode', 'generate', {
+			input_text_length: qrInputText.length,
+			is_url: /^https?:\/\//i.test(qrInputText.trim()) ? 1 : 0,
+			non_empty: qrInputText.length > 0 ? 1 : 0,
+			succeeded: ok
+		});
+	}
+
+	function trackDownload() {
+		trackToolsUsageEvent('qrcode', 'download', { input_text_length: qrInputText.length });
 	}
 
 	const pageTitle = 'TxtWizard | Free Online QR Code Generator';
@@ -40,7 +54,7 @@
 	<div class="form-group" style="text-align: center;">
 		{#if qrCodeDataUrl}
 			<img src={qrCodeDataUrl} alt="Generated QR Code" />
-			<a href={qrCodeDataUrl} download="qrcode.png">Download QR Code</a>
+			<a href={qrCodeDataUrl} download="qrcode.png" on:click={trackDownload}>Download QR Code</a>
 		{/if}
 	</div>
 </div>
@@ -61,6 +75,8 @@
 		}
 	]}
 />
+
+<RelatedTools tool="qrcode" />
 
 <div class="description">
 	<h2>What is a QR Code?</h2>

--- a/src/routes/regex/+page.svelte
+++ b/src/routes/regex/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import SeoHead from '$lib/components/SeoHead.svelte';
+	import RelatedTools from '$lib/components/RelatedTools.svelte';
 	import { t } from 'svelte-i18n';
 	import { trackToolsUsageEvent } from '$lib/utils/analytics';
 	import {
@@ -226,6 +227,7 @@
 			<li>Patterns are compiled with the JavaScript engine, so syntax follows ECMAScript regex.</li>
 		</ul>
 	</section>
+	<RelatedTools tool="regex" />
 </main>
 
 <style>

--- a/src/routes/timestamp/+page.svelte
+++ b/src/routes/timestamp/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import SeoHead from '$lib/components/SeoHead.svelte';
+	import RelatedTools from '$lib/components/RelatedTools.svelte';
 	import { t } from 'svelte-i18n';
 	import { onDestroy, onMount } from 'svelte';
 	import { trackToolsUsageEvent } from '$lib/utils/analytics';
@@ -167,6 +168,7 @@
 			<li><code>2025-01-01T00:00:00Z</code> &rarr; 1735689600 / 1735689600000</li>
 		</ul>
 	</section>
+	<RelatedTools tool="timestamp" />
 </main>
 
 <style>


### PR DESCRIPTION
GA4→BigQuery 첫 7일 baseline(2026-07-30~08-05)에서 나온 문제를 코드로 정리했습니다. 어필리에이트 박스 추가 커밋 2개도 아직 main에 없어 함께 포함됩니다.

## 데이터에서 나온 문제

| 발견 | 수치 |
|---|---|
| 봇/무참여 트래픽 | 전체 110명 중 48명(43.6%). 그 중 30명이 싱가포르-Chrome-desktop-direct 단일 패턴, 28/30이 홈에만 착륙 |
| 실질 1위 페이지는 홈이 아니라 `/compression` | 봇 제외 27명, 유저당 체류 63.6초. 홈은 8.4초 |
| 정작 그 compression에 계측 없음 | `tools_usage`는 decryption 26 / encryption 16 / hashing 2가 전부 |
| 도구 간 이동이 없음 | 세션당 PV 1.19, 단일 PV 세션 84% |

`/compression`은 google·bing·duckduckgo·yandex·chatgpt 전 채널의 organic 진입점이고, 34개 세션이 홈을 거치지 않고 직접 랜딩합니다.

## 변경

**계측 공백 해소** — 남아 있던 8개 도구(analyzer, comparison, date-calculator, encoding-decoding, jwt, key-generation, password-generator, qrcode)에 `tools_usage`를 추가했습니다. 버튼 없이 입력 중 결과가 갱신되는 analyzer / encoding-decoding / jwt decode는 디바운스로 보내고, 빈 초기 상태는 제외해 페이지 로드만으로 사용이 잡히지 않게 했습니다.

**도구 간 크로스링크** — 실제 작업 흐름을 따르는 연관 도구 카드를 전 도구 페이지에 추가했습니다(압축 → Base64 출력 확인, 암호화 → 복호화, 키 생성 → 사용). 클릭은 `related_tool_click` 이벤트로 남아 PV/세션 개선 여부를 데이터로 검증할 수 있습니다.

**광고 배치** — 수동 유닛을 어필리에이트 박스 아래에서 결과 영역 바로 아래로 올렸습니다. 설명 문단이 둘인 compression에는 본문 중간 `articleInline` 유닛을 하나 더 두었습니다.

**봇 필터링** — 두 겹입니다.

```mermaid
flowchart TD
    V["방문"] --> D{"isLikelyAutomated<br/>navigator.webdriver 또는 headless UA"}
    D -->|"예"| A1["GA4 user property<br/>traffic_quality=automated"]
    D -->|"아니오"| A2["traffic_quality=human"]
    A1 --> N["수동 광고 유닛 렌더 안 함<br/>무효 노출 방지"]
    A2 --> Y["광고 유닛 정상 렌더"]
    A1 --> BQ["BigQuery"]
    A2 --> BQ
    BQ --> F{"참여 신호가 하나라도 있는가<br/>engagement / user_engagement / tools_usage"}
    F -->|"없음"| X["v_events_human에서 제외<br/>위장한 봇까지 잡는 백스톱"]
    F -->|"있음"| K["분석 대상"]
```

수집 측 판정은 실제 방문자를 떨어뜨리지 않도록 `navigator.webdriver`와 headless/bot UA만 봅니다. 위장한 봇은 통과할 수 있어, BigQuery 분석 뷰에서 참여 신호가 전혀 없는 사용자를 걸러내는 백스톱을 함께 뒀습니다.

## 배포 후 할 일

- [ ] AdSense 콘솔에서 반응형 Display 유닛 생성 후 `src/lib/ads.ts`의 `articleInline` 슬롯 id 채우기. 비어 있으면 아무것도 렌더하지 않으므로 지금 머지해도 안전합니다.

## 검증

- `npm run check` — 0 errors, 0 warnings
- `npm run test:unit` — 79 tests 통과
- `npm run build` — 정상
- Playwright integration 테스트는 로컬에 브라우저 바이너리가 없어 실행하지 못했습니다(기존 상태, 이번 변경과 무관).

BigQuery 분석 뷰(`vzyxor.txtwizard_analytics.*`)와 그 SQL·가이드는 `docs/analytics/`에 있으며, 개인 GA4 계정 자산이라 gitignore로 로컬에만 둡니다.